### PR TITLE
Basic Groups support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,2 +1,8 @@
 inherit_from:
   - https://raw.githubusercontent.com/lessonly/rubocop-default-configuration/master/.rubocop.yml
+
+Metrics/BlockLength:
+  # don't warn about block length in block-centered DSLs
+  Exclude:
+    - 'config/routes.rb'
+    - 'spec/**/*.rb'

--- a/app/controllers/concerns/scim_rails/exception_handler.rb
+++ b/app/controllers/concerns/scim_rails/exception_handler.rb
@@ -11,6 +11,9 @@ module ScimRails
     class UnsupportedPatchRequest < StandardError
     end
 
+    class UnsupportedDeleteRequest < StandardError
+    end
+
     included do
       if Rails.env.production?
         rescue_from StandardError do |exception|
@@ -62,6 +65,17 @@ module ScimRails
             status: "422"
           },
           :unprocessable_entity
+        )
+      end
+
+      rescue_from ScimRails::ExceptionHandler::UnsupportedDeleteRequest do
+        json_response(
+          {
+            schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"],
+            detail: "Delete operation is disabled for the requested resource.",
+            status: "501"
+          },
+          :not_implemented
         )
       end
 

--- a/app/controllers/concerns/scim_rails/exception_handler.rb
+++ b/app/controllers/concerns/scim_rails/exception_handler.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ScimRails
   module ExceptionHandler
     extend ActiveSupport::Concern

--- a/app/controllers/concerns/scim_rails/response.rb
+++ b/app/controllers/concerns/scim_rails/response.rb
@@ -49,16 +49,15 @@ module ScimRails
     end
 
     def object_response(object)
-      schema =
-        case object
-        when ScimRails.config.scim_users_model
-          ScimRails.config.user_schema
-        when ScimRails.config.scim_groups_model
-          ScimRails.config.group_schema
-        else
-          raise ScimRails::ExceptionHandler::InvalidQuery,
-                "Unknown model: #{object}"
-        end
+      schema = case object
+               when ScimRails.config.scim_users_model
+                 ScimRails.config.user_schema
+               when ScimRails.config.scim_groups_model
+                 ScimRails.config.group_schema
+               else
+                 raise ScimRails::ExceptionHandler::InvalidQuery,
+                       "Unknown model: #{object}"
+               end
       find_value(object, schema)
     end
 
@@ -85,11 +84,7 @@ module ScimRails
       when ScimRails.config.scim_groups_model
         find_value(schema, ScimRails.config.group_abbreviated_schema)
       when Symbol
-        value = object.public_send(schema)
-        case value
-        when true, false, String, Integer, DateTime then value
-        else find_value(object, value)
-        end
+        find_value(object, object.public_send(schema))
       else
         schema
       end

--- a/app/controllers/concerns/scim_rails/response.rb
+++ b/app/controllers/concerns/scim_rails/response.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 module ScimRails
   module Response
-    CONTENT_TYPE = "application/scim+json".freeze
+    CONTENT_TYPE = "application/scim+json"
 
     def json_response(object, status = :ok)
       render \
@@ -32,13 +34,13 @@ module ScimRails
         .offset(counts.offset)
         .limit(counts.limit)
       {
-        "schemas": [
-            "urn:ietf:params:scim:api:messages:2.0:ListResponse"
+        schemas: [
+          "urn:ietf:params:scim:api:messages:2.0:ListResponse"
         ],
-        "totalResults": counts.total,
-        "startIndex": counts.start_index,
-        "itemsPerPage": counts.limit,
-        "Resources": list_objects(object)
+        totalResults: counts.total,
+        startIndex: counts.start_index,
+        itemsPerPage: counts.limit,
+        Resources: list_objects(object)
       }
     end
 
@@ -60,7 +62,6 @@ module ScimRails
                end
       find_value(object, schema)
     end
-
 
     # `find_value` is a recursive method that takes a "user" and a
     # "user schema" and replaces any symbols in the schema with the

--- a/app/controllers/concerns/scim_rails/response.rb
+++ b/app/controllers/concerns/scim_rails/response.rb
@@ -18,7 +18,7 @@ module ScimRails
           content_type: CONTENT_TYPE
       when "show", "create", "put_update", "patch_update"
         render \
-          json: user_response(object),
+          json: object_response(object),
           status: status,
           content_type: CONTENT_TYPE
       end
@@ -38,19 +38,28 @@ module ScimRails
         "totalResults": counts.total,
         "startIndex": counts.start_index,
         "itemsPerPage": counts.limit,
-        "Resources": list_users(object)
+        "Resources": list_objects(object)
       }
     end
 
-    def list_users(users)
-      users.map do |user|
-        user_response(user)
+    def list_objects(objects)
+      objects.map do |object|
+        object_response(object)
       end
     end
 
-    def user_response(user)
-      schema = ScimRails.config.user_schema
-      find_value(user, schema)
+    def object_response(object)
+      schema =
+        case object
+        when ScimRails.config.scim_users_model
+          ScimRails.config.user_schema
+        when ScimRails.config.scim_groups_model
+          ScimRails.config.group_schema
+        else
+          raise ScimRails::ExceptionHandler::InvalidQuery,
+                "Unknown model: #{object}"
+        end
+      find_value(object, schema)
     end
 
 
@@ -61,20 +70,28 @@ module ScimRails
     # send those symbols to the model, and replace the symbol with
     # the return value.
 
-    def find_value(user, object)
-      case object
+    def find_value(object, schema)
+      case schema
       when Hash
-        object.each.with_object({}) do |(key, value), hash|
-          hash[key] = find_value(user, value)
+        schema.each.with_object({}) do |(key, value), hash|
+          hash[key] = find_value(object, value)
         end
-      when Array
-        object.map do |value|
-          find_value(user, value)
+      when Array, ActiveRecord::Associations::CollectionProxy
+        schema.map do |value|
+          find_value(object, value)
         end
+      when ScimRails.config.scim_users_model
+        find_value(schema, ScimRails.config.user_abbreviated_schema)
+      when ScimRails.config.scim_groups_model
+        find_value(schema, ScimRails.config.group_abbreviated_schema)
       when Symbol
-        user.public_send(object)
+        value = object.public_send(schema)
+        case value
+        when true, false, String, Integer, DateTime then value
+        else find_value(object, value)
+        end
       else
-        object
+        schema
       end
     end
   end

--- a/app/controllers/scim_rails/application_controller.rb
+++ b/app/controllers/scim_rails/application_controller.rb
@@ -34,5 +34,37 @@ module ScimRails
 
       yield searchable_attribute, authentication_attribute
     end
+
+    def find_value_for(attribute)
+      params.dig(*path_for(attribute))
+    end
+
+    # `path_for` is a recursive method used to find the "path" for
+    # `.dig` to take when looking for a given attribute in the
+    # params.
+    #
+    # Example: `path_for(:name)` should return an array that looks
+    # like [:names, 0, :givenName]. `.dig` can then use that path
+    # against the params to translate the :name attribute to "John".
+
+    def path_for(attribute, object = controller_schema, path = [])
+      at_path = path.empty? ? object : object.dig(*path)
+      return path if at_path == attribute
+
+      case at_path
+      when Hash
+        at_path.each do |key, value|
+          found_path = path_for(attribute, object, [*path, key])
+          return found_path if found_path
+        end
+        nil
+      when Array
+        at_path.each_with_index do |value, index|
+          found_path = path_for(attribute, object, [*path, index])
+          return found_path if found_path
+        end
+        nil
+      end
+    end
   end
 end

--- a/app/controllers/scim_rails/application_controller.rb
+++ b/app/controllers/scim_rails/application_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ScimRails
   class ApplicationController < ActionController::API
     include ActionController::HttpAuthentication::Basic::ControllerMethods
@@ -28,7 +30,7 @@ module ScimRails
     end
 
     def authenticate_with_oauth_bearer
-      authentication_attribute = request.headers["Authorization"].split(" ").last
+      authentication_attribute = request.headers["Authorization"].split.last
       payload = ScimRails::Encoder.decode(authentication_attribute).with_indifferent_access
       searchable_attribute = payload[ScimRails.config.basic_auth_model_searchable_attribute]
 

--- a/app/controllers/scim_rails/application_controller.rb
+++ b/app/controllers/scim_rails/application_controller.rb
@@ -53,13 +53,13 @@ module ScimRails
 
       case at_path
       when Hash
-        at_path.each do |key, value|
+        at_path.each do |key, _value|
           found_path = path_for(attribute, object, [*path, key])
           return found_path if found_path
         end
         nil
       when Array
-        at_path.each_with_index do |value, index|
+        at_path.each_with_index do |_value, index|
           found_path = path_for(attribute, object, [*path, index])
           return found_path if found_path
         end

--- a/app/controllers/scim_rails/scim_groups_controller.rb
+++ b/app/controllers/scim_rails/scim_groups_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ScimRails
   class ScimGroupsController < ScimRails::ApplicationController
     def index
@@ -70,6 +72,7 @@ module ScimRails
         hash[attribute] = find_value_for(attribute)
       end
       return converted unless params[:members]
+
       converted.merge(member_params)
     end
 

--- a/app/controllers/scim_rails/scim_groups_controller.rb
+++ b/app/controllers/scim_rails/scim_groups_controller.rb
@@ -30,7 +30,9 @@ module ScimRails
     end
 
     def show
-      group = @company.public_send(ScimRails.config.scim_groups_scope).find(params[:id])
+      group = @company
+        .public_send(ScimRails.config.scim_groups_scope)
+        .find(params[:id])
       json_scim_response(object: group)
     end
 
@@ -43,7 +45,9 @@ module ScimRails
     end
 
     def put_update
-      group = @company.public_send(ScimRails.config.scim_groups_scope).find(params[:id])
+      group = @company
+        .public_send(ScimRails.config.scim_groups_scope)
+        .find(params[:id])
       group.update!(permitted_group_params)
       json_scim_response(object: group)
     end
@@ -52,7 +56,9 @@ module ScimRails
       unless ScimRails.config.group_destroy_method
         raise ScimRails::ExceptionHandler::UnsupportedDeleteRequest
       end
-      group = @company.public_send(ScimRails.config.scim_groups_scope).find(params[:id])
+      group = @company
+        .public_send(ScimRails.config.scim_groups_scope)
+        .find(params[:id])
       group.public_send(ScimRails.config.group_destroy_method)
       head :no_content
     end
@@ -60,16 +66,24 @@ module ScimRails
     private
 
     def permitted_group_params
-      converted = ScimRails.config.mutable_group_attributes.each.with_object({}) do |attribute, hash|
+      converted = mutable_attributes.each.with_object({}) do |attribute, hash|
         hash[attribute] = find_value_for(attribute)
       end
       return converted unless params[:members]
-      converted.merge(
+      converted.merge(member_params)
+    end
+
+    def member_params
+      {
         ScimRails.config.group_member_relation_attribute =>
           params[:members].map do |member|
             member[ScimRails.config.group_member_relation_schema.keys.first]
           end
-      )
+      }
+    end
+
+    def mutable_attributes
+      ScimRails.config.mutable_group_attributes
     end
 
     def controller_schema

--- a/app/controllers/scim_rails/scim_groups_controller.rb
+++ b/app/controllers/scim_rails/scim_groups_controller.rb
@@ -1,0 +1,66 @@
+module ScimRails
+  class ScimGroupsController < ScimRails::ApplicationController
+    def index
+      if params[:filter].present?
+        query = ScimRails::ScimQueryParser.new(params[:filter])
+
+        groups = @company
+          .public_send(ScimRails.config.scim_groups_scope)
+          .where(
+            "#{ScimRails.config.scim_groups_model.connection.quote_column_name(query.attribute)} #{query.operator} ?",
+            query.parameter
+          )
+          .order(ScimRails.config.scim_groups_list_order)
+      else
+        groups = @company
+          .public_send(ScimRails.config.scim_groups_scope)
+          .preload(:users)
+          .order(ScimRails.config.scim_groups_list_order)
+      end
+
+      counts = ScimCount.new(
+        start_index: params[:startIndex],
+        limit: params[:count],
+        total: groups.count
+      )
+
+      json_scim_response(object: groups, counts: counts)
+    end
+
+    def show
+      group = @company.public_send(ScimRails.config.scim_groups_scope).find(params[:id])
+      json_scim_response(object: group)
+    end
+
+    def create
+      group = @company
+        .public_send(ScimRails.config.scim_groups_scope)
+        .create!(permitted_group_params)
+
+      json_scim_response(object: group, status: :created)
+    end
+
+    def put_update
+      group = @company.public_send(ScimRails.config.scim_groups_scope).find(params[:id])
+      group.update!(permitted_group_params)
+      json_scim_response(object: group)
+    end
+
+    private
+
+    def permitted_group_params
+      ScimRails.config.mutable_group_attributes.each.with_object({}) do |attribute, hash|
+        hash[attribute] = find_value_for(attribute)
+      end.merge(
+        ScimRails.config.group_member_relation_attribute =>
+          params[:members].map do |member|
+            member[ScimRails.config.group_member_relation_schema.keys.first]
+          end
+      )
+    end
+
+    def controller_schema
+      ScimRails.config.mutable_group_attributes_schema
+    end
+  end
+end

--- a/app/controllers/scim_rails/scim_groups_controller.rb
+++ b/app/controllers/scim_rails/scim_groups_controller.rb
@@ -46,6 +46,15 @@ module ScimRails
       json_scim_response(object: group)
     end
 
+    def destroy
+      unless ScimRails.config.group_destroy_method
+        raise ScimRails::ExceptionHandler::UnsupportedDeleteRequest
+      end
+      group = @company.public_send(ScimRails.config.scim_groups_scope).find(params[:id])
+      group.public_send(ScimRails.config.group_destroy_method)
+      json_response(nil, :no_content)
+    end
+
     private
 
     def permitted_group_params

--- a/app/controllers/scim_rails/scim_users_controller.rb
+++ b/app/controllers/scim_rails/scim_users_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ScimRails
   class ScimUsersController < ScimRails::ApplicationController
     def index
@@ -33,7 +35,7 @@ module ScimRails
         user = @company.public_send(ScimRails.config.scim_users_scope).create!(permitted_user_params)
       else
         username_key = ScimRails.config.queryable_user_attributes[:userName]
-        find_by_username = Hash.new
+        find_by_username = {}
         find_by_username[username_key] = permitted_user_params[username_key]
         user = @company
           .public_send(ScimRails.config.scim_users_scope)

--- a/app/controllers/scim_rails/scim_users_controller.rb
+++ b/app/controllers/scim_rails/scim_users_controller.rb
@@ -2,7 +2,9 @@ module ScimRails
   class ScimUsersController < ScimRails::ApplicationController
     def index
       if params[:filter].present?
-        query = ScimRails::ScimQueryParser.new(params[:filter])
+        query = ScimRails::ScimQueryParser.new(
+          params[:filter], ScimRails.config.queryable_user_attributes
+        )
 
         users = @company
           .public_send(ScimRails.config.scim_users_scope)

--- a/app/controllers/scim_rails/scim_users_controller.rb
+++ b/app/controllers/scim_rails/scim_users_controller.rb
@@ -70,36 +70,8 @@ module ScimRails
       end
     end
 
-    def find_value_for(attribute)
-      params.dig(*path_for(attribute))
-    end
-
-    # `path_for` is a recursive method used to find the "path" for
-    # `.dig` to take when looking for a given attribute in the
-    # params.
-    #
-    # Example: `path_for(:name)` should return an array that looks
-    # like [:names, 0, :givenName]. `.dig` can then use that path
-    # against the params to translate the :name attribute to "John".
-
-    def path_for(attribute, object = ScimRails.config.mutable_user_attributes_schema, path = [])
-      at_path = path.empty? ? object : object.dig(*path)
-      return path if at_path == attribute
-
-      case at_path
-      when Hash
-        at_path.each do |key, value|
-          found_path = path_for(attribute, object, [*path, key])
-          return found_path if found_path
-        end
-        nil
-      when Array
-        at_path.each_with_index do |value, index|
-          found_path = path_for(attribute, object, [*path, index])
-          return found_path if found_path
-        end
-        nil
-      end
+    def controller_schema
+      ScimRails.config.mutable_user_attributes_schema
     end
 
     def update_status(user)

--- a/app/models/scim_rails/scim_query_parser.rb
+++ b/app/models/scim_rails/scim_query_parser.rb
@@ -26,7 +26,7 @@ module ScimRails
     end
 
     def parameter
-      parameter = query_elements[2..].join(" ")
+      parameter = query_elements[2..-1].join(" ")
       return if parameter.blank?
 
       parameter.gsub(/"/, "")

--- a/app/models/scim_rails/scim_query_parser.rb
+++ b/app/models/scim_rails/scim_query_parser.rb
@@ -1,29 +1,34 @@
+# frozen_string_literal: true
+
 module ScimRails
   class ScimQueryParser
     attr_accessor :query_elements, :query_attributes
 
     def initialize(query_string, queryable_attributes)
-      self.query_elements = query_string.split(" ")
+      self.query_elements = query_string.split
       self.query_attributes = queryable_attributes
     end
 
     def attribute
-      attribute = query_elements.dig(0)
+      attribute = query_elements[0]
       raise ScimRails::ExceptionHandler::InvalidQuery if attribute.blank?
+
       attribute = attribute.to_sym
 
       mapped_attribute = query_attributes[attribute]
       raise ScimRails::ExceptionHandler::InvalidQuery if mapped_attribute.blank?
+
       mapped_attribute
     end
 
     def operator
-      sql_comparison_operator(query_elements.dig(1))
+      sql_comparison_operator(query_elements[1])
     end
 
     def parameter
-      parameter = query_elements[2..-1].join(" ")
+      parameter = query_elements[2..].join(" ")
       return if parameter.blank?
+
       parameter.gsub(/"/, "")
     end
 

--- a/app/models/scim_rails/scim_query_parser.rb
+++ b/app/models/scim_rails/scim_query_parser.rb
@@ -1,9 +1,10 @@
 module ScimRails
   class ScimQueryParser
-    attr_accessor :query_elements
+    attr_accessor :query_elements, :query_attributes
 
-    def initialize(query_string)
+    def initialize(query_string, queryable_attributes)
       self.query_elements = query_string.split(" ")
+      self.query_attributes = queryable_attributes
     end
 
     def attribute
@@ -11,7 +12,7 @@ module ScimRails
       raise ScimRails::ExceptionHandler::InvalidQuery if attribute.blank?
       attribute = attribute.to_sym
 
-      mapped_attribute = attribute_mapping(attribute)
+      mapped_attribute = query_attributes[attribute]
       raise ScimRails::ExceptionHandler::InvalidQuery if mapped_attribute.blank?
       mapped_attribute
     end
@@ -27,10 +28,6 @@ module ScimRails
     end
 
     private
-
-    def attribute_mapping(attribute)
-      ScimRails.config.queryable_user_attributes[attribute]
-    end
 
     def sql_comparison_operator(element)
       case element

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,4 +4,9 @@ ScimRails::Engine.routes.draw do
   get    'scim/v2/Users/:id',  action: :show,          controller: 'scim_users'
   put    'scim/v2/Users/:id',  action: :put_update,    controller: 'scim_users'
   patch  'scim/v2/Users/:id',  action: :patch_update,  controller: 'scim_users'
+  get    'scim/v2/Groups',     action: :index,         controller: 'scim_groups'
+  post   'scim/v2/Groups',     action: :create,        controller: 'scim_groups'
+  get    'scim/v2/Groups/:id', action: :show,          controller: 'scim_groups'
+  put    'scim/v2/Groups/:id', action: :put_update,    controller: 'scim_groups'
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,5 +8,5 @@ ScimRails::Engine.routes.draw do
   post   'scim/v2/Groups',     action: :create,        controller: 'scim_groups'
   get    'scim/v2/Groups/:id', action: :show,          controller: 'scim_groups'
   put    'scim/v2/Groups/:id', action: :put_update,    controller: 'scim_groups'
-
+  delete 'scim/v2/Groups/:id', action: :destroy,       controller: 'scim_groups'
 end

--- a/lib/generators/scim_rails/templates/initializer.rb
+++ b/lib/generators/scim_rails/templates/initializer.rb
@@ -152,4 +152,8 @@ ScimRails.configure do |config|
     value: :id,
     display: :name
   }
+
+  # Set group_destroy_method to a method on the Group model
+  # to be called on a destroy request
+  # config.group_destroy_method = :destroy!
 end

--- a/lib/generators/scim_rails/templates/initializer.rb
+++ b/lib/generators/scim_rails/templates/initializer.rb
@@ -22,6 +22,12 @@ ScimRails.configure do |config|
   # or throws an error (returning 409 Conflict in accordance with SCIM spec)
   config.scim_user_prevent_update_on_create = false
 
+  # Model used for group records.
+  config.scim_groups_model = 'Group'
+  # Method used for retrieving user records from the
+  # authenticatable model.
+  config.scim_groups_scope = :groups
+
   # Cryptographic algorithm used for signing the auth tokens.
   # It supports all algorithms supported by the jwt gem.
   # See https://github.com/jwt/ruby-jwt#algorithms-and-usage for supported algorithms
@@ -104,5 +110,46 @@ ScimRails.configure do |config|
       },
     ],
     active: :active?
+  }
+
+  # Schema for users used in "abbreviated" lists such as in
+  # the `members` field of a Group.
+  config.user_abbreviated_schema = {
+    value: :id,
+    display: :email
+  }
+
+  # List of attributes on a Group that can be updated through SCIM
+  config.mutable_group_attributes = [
+    :name
+  ]
+
+  # Hash of mutable Group attributes. This object is the map
+  # for this Gem to figure out where to look in a SCIM
+  # response for mutable values. This object should
+  # include all attributes listed in
+  # config.mutable_group_attributes.
+  config.mutable_group_attributes_schema = {
+    displayName: :name
+  }
+
+  # The User relation's IDs field name on the Group model.
+  # Eg. if the relation is `has_many :users` this will be :user_ids
+  config.group_member_relation_attribute = :user_ids
+  # Which fields from the request's `members` field should be
+  # assigned to the relation IDs field. Should include the field
+  # set in config.group_member_relation_attribute.
+  config.group_member_relation_schema = { value: :user_ids }
+
+  config.group_schema = {
+    schemas: ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+    id: :id,
+    displayName: :name,
+    members: :users
+  }
+
+  config.group_abbreviated_schema = {
+    value: :id,
+    display: :name
   }
 end

--- a/lib/generators/scim_rails/templates/initializer.rb
+++ b/lib/generators/scim_rails/templates/initializer.rb
@@ -119,6 +119,11 @@ ScimRails.configure do |config|
     display: :email
   }
 
+  # Allow filtering Groups based on these parameters
+  config.queryable_group_attributes = {
+    displayName: :name
+  }
+
   # List of attributes on a Group that can be updated through SCIM
   config.mutable_group_attributes = [
     :name

--- a/lib/generators/scim_rails/templates/initializer.rb
+++ b/lib/generators/scim_rails/templates/initializer.rb
@@ -23,7 +23,7 @@ ScimRails.configure do |config|
   config.scim_user_prevent_update_on_create = false
 
   # Model used for group records.
-  config.scim_groups_model = 'Group'
+  config.scim_groups_model = "Group"
   # Method used for retrieving user records from the
   # authenticatable model.
   config.scim_groups_scope = :groups

--- a/lib/generators/scim_rails/templates/initializer.rb
+++ b/lib/generators/scim_rails/templates/initializer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ScimRails.configure do |config|
   # Model used for authenticating and scoping users.
   config.basic_auth_model = "Company"
@@ -107,7 +109,7 @@ ScimRails.configure do |config|
     emails: [
       {
         value: :email
-      },
+      }
     ],
     active: :active?
   }

--- a/lib/scim_rails/config.rb
+++ b/lib/scim_rails/config.rb
@@ -44,7 +44,8 @@ module ScimRails
       :user_deprovision_method,
       :user_reprovision_method,
       :user_schema,
-      :group_schema
+      :group_schema,
+      :group_destroy_method
 
     def initialize
       @basic_auth_model = "Company"

--- a/lib/scim_rails/config.rb
+++ b/lib/scim_rails/config.rb
@@ -18,6 +18,7 @@ module ScimRails
     attr_writer \
       :basic_auth_model,
       :mutable_user_attributes_schema,
+      :mutable_group_attributes_schema,
       :scim_users_model
 
     attr_accessor \
@@ -29,24 +30,42 @@ module ScimRails
       :scim_users_list_order,
       :scim_users_scope,
       :scim_user_prevent_update_on_create,
+      :mutable_group_attributes,
+      :scim_groups_list_order,
+      :scim_groups_model,
+      :scim_groups_scope,
+      :group_member_relation_attribute,
+      :group_member_relation_schema,
+      :user_abbreviated_schema,
+      :group_abbreviated_schema,
       :signing_secret,
       :signing_algorithm,
       :user_attributes,
       :user_deprovision_method,
       :user_reprovision_method,
-      :user_schema
+      :user_schema,
+      :group_schema
 
     def initialize
       @basic_auth_model = "Company"
       @scim_users_list_order = :id
       @scim_users_model = "User"
+      @scim_groups_list_order = :id
+      @scim_groups_model = 'Group'
       @signing_algorithm = ALGO_NONE
       @user_schema = {}
       @user_attributes = []
+      @user_abbreviated_schema = {}
+      @group_schema = {}
+      @group_abbreviated_schema = {}
     end
 
     def mutable_user_attributes_schema
       @mutable_user_attributes_schema || @user_schema
+    end
+
+    def mutable_group_attributes_schema
+      @mutable_group_attributes_schema || @group_schema
     end
 
     def basic_auth_model
@@ -55,6 +74,10 @@ module ScimRails
 
     def scim_users_model
       @scim_users_model.constantize
+    end
+
+    def scim_groups_model
+      @scim_groups_model.constantize
     end
   end
 end

--- a/lib/scim_rails/config.rb
+++ b/lib/scim_rails/config.rb
@@ -27,6 +27,7 @@ module ScimRails
       :mutable_user_attributes,
       :on_error,
       :queryable_user_attributes,
+      :queryable_group_attributes,
       :scim_users_list_order,
       :scim_users_scope,
       :scim_user_prevent_update_on_create,

--- a/lib/scim_rails/config.rb
+++ b/lib/scim_rails/config.rb
@@ -19,7 +19,8 @@ module ScimRails
       :basic_auth_model,
       :mutable_user_attributes_schema,
       :mutable_group_attributes_schema,
-      :scim_users_model
+      :scim_users_model,
+      :scim_groups_model
 
     attr_accessor \
       :basic_auth_model_authenticatable_attribute,
@@ -33,7 +34,6 @@ module ScimRails
       :scim_user_prevent_update_on_create,
       :mutable_group_attributes,
       :scim_groups_list_order,
-      :scim_groups_model,
       :scim_groups_scope,
       :group_member_relation_attribute,
       :group_member_relation_schema,
@@ -53,7 +53,7 @@ module ScimRails
       @scim_users_list_order = :id
       @scim_users_model = "User"
       @scim_groups_list_order = :id
-      @scim_groups_model = 'Group'
+      @scim_groups_model = "Group"
       @signing_algorithm = ALGO_NONE
       @user_schema = {}
       @user_attributes = []

--- a/spec/controllers/scim_rails/scim_groups_controller_spec.rb
+++ b/spec/controllers/scim_rails/scim_groups_controller_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe ScimRails::ScimGroupsController, type: :controller do
       it "fails with invalid credentials" do
         request.env["HTTP_AUTHORIZATION"] =
           ActionController::HttpAuthentication::Basic
-            .encode_credentials("unauthorized", "123456")
+          .encode_credentials("unauthorized", "123456")
 
         get :index, as: :json
 
@@ -157,7 +157,7 @@ RSpec.describe ScimRails::ScimGroupsController, type: :controller do
       it "fails with invalid credentials" do
         request.env["HTTP_AUTHORIZATION"] =
           ActionController::HttpAuthentication::Basic
-            .encode_credentials("unauthorized", "123456")
+          .encode_credentials("unauthorized", "123456")
 
         get :show, params: { id: 1 }, as: :json
 
@@ -219,7 +219,7 @@ RSpec.describe ScimRails::ScimGroupsController, type: :controller do
       it "fails with invalid credentials" do
         request.env["HTTP_AUTHORIZATION"] =
           ActionController::HttpAuthentication::Basic
-            .encode_credentials("unauthorized", "123456")
+          .encode_credentials("unauthorized", "123456")
 
         post :create, as: :json
 
@@ -327,7 +327,7 @@ RSpec.describe ScimRails::ScimGroupsController, type: :controller do
       it "fails with invalid credentials" do
         request.env["HTTP_AUTHORIZATION"] =
           ActionController::HttpAuthentication::Basic
-            .encode_credentials("unauthorized", "123456")
+          .encode_credentials("unauthorized", "123456")
 
         put :put_update, params: { id: 1 }, as: :json
 
@@ -410,7 +410,7 @@ RSpec.describe ScimRails::ScimGroupsController, type: :controller do
       it "fails with invalid credentials" do
         request.env["HTTP_AUTHORIZATION"] =
           ActionController::HttpAuthentication::Basic
-            .encode_credentials("unauthorized", "123456")
+          .encode_credentials("unauthorized", "123456")
 
         delete :destroy, params: { id: 1 }, as: :json
 

--- a/spec/controllers/scim_rails/scim_groups_controller_spec.rb
+++ b/spec/controllers/scim_rails/scim_groups_controller_spec.rb
@@ -22,7 +22,9 @@ RSpec.describe ScimRails::ScimGroupsController, type: :controller do
       end
 
       it "fails with invalid credentials" do
-        request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials("unauthorized","123456")
+        request.env["HTTP_AUTHORIZATION"] =
+          ActionController::HttpAuthentication::Basic
+          .encode_credentials("unauthorized", "123456")
 
         get :index, as: :json
 
@@ -145,7 +147,9 @@ RSpec.describe ScimRails::ScimGroupsController, type: :controller do
       end
 
       it "fails with invalid credentials" do
-        request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials("unauthorized","123456")
+        request.env['HTTP_AUTHORIZATION'] =
+          ActionController::HttpAuthentication::Basic
+          .encode_credentials("unauthorized", "123456")
 
         get :show, params: { id: 1 }, as: :json
 
@@ -392,7 +396,9 @@ RSpec.describe ScimRails::ScimGroupsController, type: :controller do
       end
 
       it "fails with invalid credentials" do
-        request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials("unauthorized","123456")
+        request.env['HTTP_AUTHORIZATION'] =
+          ActionController::HttpAuthentication::Basic
+          .encode_credentials("unauthorized", "123456")
 
         delete :destroy, params: { id: 1 }, as: :json
 
@@ -409,7 +415,9 @@ RSpec.describe ScimRails::ScimGroupsController, type: :controller do
 
       context "when Group destroy method is configured" do
         before do
-          allow(ScimRails.config).to receive(:group_destroy_method).and_return(:destroy!)
+          allow(ScimRails.config).to(
+            receive(:group_destroy_method).and_return(:destroy!)
+          )
         end
 
         it "returns empty response" do
@@ -450,7 +458,9 @@ RSpec.describe ScimRails::ScimGroupsController, type: :controller do
 
       context "when Group destroy method is not configured" do
         it "does not delete Group" do
-          allow(ScimRails.config).to receive(:group_destroy_method).and_return(nil)
+          allow(ScimRails.config).to(
+            receive(:group_destroy_method).and_return(nil)
+          )
 
           expect do
             delete :destroy, params: { id: 1 }, as: :json

--- a/spec/controllers/scim_rails/scim_groups_controller_spec.rb
+++ b/spec/controllers/scim_rails/scim_groups_controller_spec.rb
@@ -1,0 +1,472 @@
+require "spec_helper"
+
+RSpec.describe ScimRails::ScimGroupsController, type: :controller do
+  include AuthHelper
+
+  routes { ScimRails::Engine.routes }
+
+  describe "index" do
+    let(:company) { create(:company) }
+
+    context "when unauthorized" do
+      it "returns scim+json content type" do
+        get :index, as: :json
+
+        expect(response.media_type).to eq "application/scim+json"
+      end
+
+      it "fails with no credentials" do
+        get :index, as: :json
+
+        expect(response.status).to eq 401
+      end
+
+      it "fails with invalid credentials" do
+        request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials("unauthorized","123456")
+
+        get :index, as: :json
+
+        expect(response.status).to eq 401
+      end
+    end
+
+    context "when authorized" do
+      before :each do
+        http_login(company)
+      end
+
+      it "returns scim+json content type" do
+        get :index, as: :json
+
+        expect(response.media_type).to eq "application/scim+json"
+      end
+
+      it "is successful with valid credentials" do
+        get :index, as: :json
+
+        expect(response.status).to eq 200
+      end
+
+      it "returns all results" do
+        create_list(:group, 5, company: company)
+
+        get :index, as: :json
+        response_body = JSON.parse(response.body)
+        expect(response_body.dig("schemas", 0)).to eq "urn:ietf:params:scim:api:messages:2.0:ListResponse"
+        expect(response_body["totalResults"]).to eq 5
+      end
+
+      it "defaults to 100 results" do
+        create_list(:group, 300, company: company)
+
+        get :index, as: :json
+        response_body = JSON.parse(response.body)
+        expect(response_body["totalResults"]).to eq 300
+        expect(response_body["Resources"].count).to eq 100
+      end
+
+      it "paginates results" do
+        create_list(:group, 400, company: company)
+        expect(company.groups.first.id).to eq 1
+
+        get :index, params: {
+          startIndex: 101,
+          count: 200,
+        }, as: :json
+        response_body = JSON.parse(response.body)
+        expect(response_body["totalResults"]).to eq 400
+        expect(response_body["Resources"].count).to eq 200
+        expect(response_body.dig("Resources", 0, "id")).to eq 101
+      end
+
+      it "paginates results by configurable scim_groups_list_order" do
+        allow(ScimRails.config).to receive(:scim_groups_list_order).and_return({ created_at: :desc })
+
+        create_list(:group, 400, company: company)
+        expect(company.groups.first.id).to eq 1
+
+        get :index, params: {
+          startIndex: 1,
+          count: 10,
+        }, as: :json
+        response_body = JSON.parse(response.body)
+        expect(response_body["totalResults"]).to eq 400
+        expect(response_body["Resources"].count).to eq 10
+        expect(response_body.dig("Resources", 0, "id")).to eq 400
+      end
+
+      it "filters results by provided displayName filter" do
+        create(:group, name: "Foo", company: company)
+        create(:group, name: "Bar", company: company)
+
+        get :index, params: {
+          filter: "displayName eq Bar"
+        }, as: :json
+        response_body = JSON.parse(response.body)
+        expect(response_body["totalResults"]).to eq 1
+        expect(response_body["Resources"].count).to eq 1
+        expect(response_body.dig("Resources", 0, "displayName")).to eq "Bar"
+      end
+
+      it "returns no results for unfound filter parameters" do
+        get :index, params: {
+          filter: "displayName eq fake_not_there"
+        }, as: :json
+        response_body = JSON.parse(response.body)
+        expect(response_body["totalResults"]).to eq 0
+        expect(response_body["Resources"].count).to eq 0
+      end
+
+      it "returns no results for undefined filter queries" do
+        get :index, params: {
+          filter: "address eq 101 Nowhere USA"
+        }, as: :json
+        expect(response.status).to eq 400
+        response_body = JSON.parse(response.body)
+        expect(response_body.dig("schemas", 0)).to eq "urn:ietf:params:scim:api:messages:2.0:Error"
+      end
+    end
+  end
+
+  describe "show" do
+    let(:company) { create(:company) }
+
+    context "when unauthorized" do
+      it "returns scim+json content type" do
+        get :show, params: { id: 1 }, as: :json
+
+        expect(response.media_type).to eq "application/scim+json"
+      end
+
+      it "fails with no credentials" do
+        get :show, params: { id: 1 }, as: :json
+
+        expect(response.status).to eq 401
+      end
+
+      it "fails with invalid credentials" do
+        request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials("unauthorized","123456")
+
+        get :show, params: { id: 1 }, as: :json
+
+        expect(response.status).to eq 401
+      end
+    end
+
+    context "when authorized" do
+      before :each do
+        http_login(company)
+      end
+
+      it "returns scim+json content type" do
+        get :show, params: { id: 1 }, as: :json
+
+        expect(response.media_type).to eq "application/scim+json"
+      end
+
+      it "is successful with valid credentials" do
+        create(:group, id: 1, company: company)
+        get :show, params: { id: 1 }, as: :json
+
+        expect(response.status).to eq 200
+      end
+
+      it "returns :not_found for id that cannot be found" do
+        get :show, params: { id: "fake_id" }, as: :json
+
+        expect(response.status).to eq 404
+      end
+
+      it "returns :not_found for a correct id but unauthorized company" do
+        new_company = create(:company)
+        create(:group, company: new_company, id: 1)
+
+        get :show, params: { id: 1 }, as: :json
+
+        expect(response.status).to eq 404
+      end
+    end
+  end
+
+  describe "create" do
+    let(:company) { create(:company) }
+
+    context "when unauthorized" do
+      it "returns scim+json content type" do
+        post :create, as: :json
+
+        expect(response.media_type).to eq "application/scim+json"
+      end
+
+      it "fails with no credentials" do
+        post :create, as: :json
+
+        expect(response.status).to eq 401
+      end
+
+      it "fails with invalid credentials" do
+        request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials("unauthorized","123456")
+
+        post :create, as: :json
+
+        expect(response.status).to eq 401
+      end
+    end
+
+    context "when authorized" do
+      before :each do
+        http_login(company)
+      end
+
+      it "returns scim+json content type" do
+        post :create, params: {
+          displayName: "Test Group",
+          members: []
+        }, as: :json
+
+        expect(response.media_type).to eq "application/scim+json"
+      end
+
+      it "is successful with valid credentials" do
+        expect(company.groups.count).to eq 0
+
+        post :create, params: {
+          displayName: "Test Group",
+          members: []
+        }, as: :json
+
+        expect(response.status).to eq 201
+        expect(company.groups.count).to eq 1
+        group = company.groups.first
+        expect(group.persisted?).to eq true
+        expect(group.name).to eq "Test Group"
+        expect(group.users).to eq []
+      end
+
+      it "ignores unconfigured params" do
+        post :create, params: {
+          displayName: "Test Group",
+          department: "Best Department",
+          members: []
+        }, as: :json
+
+        expect(response.status).to eq 201
+        expect(company.groups.count).to eq 1
+      end
+
+      it "returns 422 if required params are missing" do
+        post :create, params: {
+          members: []
+        }, as: :json
+
+        expect(response.status).to eq 422
+        expect(company.users.count).to eq 0
+      end
+
+      it "returns 409 if group already exists" do
+        create(:group, name: "Test Group", company: company)
+
+        post :create, params: {
+          displayName: "Test Group",
+          members: []
+        }, as: :json
+
+        expect(response.status).to eq 409
+        expect(company.groups.count).to eq 1
+      end
+
+      it "creates group" do
+        users = create_list(:user, 3, company: company)
+
+        post :create, params: {
+          displayName: "Test Group",
+          members: users.map do |user|
+            { value: user.id.to_s, display: user.email }
+          end
+        }, as: :json
+
+        expect(response.status).to eq 201
+        expect(company.groups.count).to eq 1
+        group = company.groups.first
+        expect(group.name).to eq "Test Group"
+        expect(group.users.count).to eq 3
+      end
+    end
+  end
+
+  describe "put update" do
+    let(:company) { create(:company) }
+
+    context "when unauthorized" do
+      it "returns scim+json content type" do
+        put :put_update, params: { id: 1 }, as: :json
+
+        expect(response.media_type).to eq "application/scim+json"
+      end
+
+      it "fails with no credentials" do
+        put :put_update, params: { id: 1 }, as: :json
+
+        expect(response.status).to eq 401
+      end
+
+      it "fails with invalid credentials" do
+        request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials("unauthorized","123456")
+
+        put :put_update, params: { id: 1 }, as: :json
+
+        expect(response.status).to eq 401
+      end
+    end
+
+    context "when authorized" do
+      let!(:group) { create(:group, id: 1, company: company) }
+
+      before :each do
+        http_login(company)
+      end
+
+      it "returns scim+json content type" do
+        put :put_update, params: put_params, as: :json
+
+        expect(response.media_type).to eq "application/scim+json"
+      end
+
+      it "is successful with with valid credentials" do
+        put :put_update, params: put_params, as: :json
+
+        expect(response.status).to eq 200
+      end
+
+      it "can add and delete Users from a Group at once" do
+        user1 = create(:user, company: company, groups: [group])
+        user2 = create(:user, company: company)
+
+        expect do
+          put :put_update, params: put_params(users: [user2]), as: :json
+        end.to change { group.reload.users }.from([user1]).to([user2])
+
+        expect(response.status).to eq 200
+      end
+
+      it "returns :not_found for id that cannot be found" do
+        put :put_update, params: { id: "fake_id" }, as: :json
+
+        expect(response.status).to eq 404
+      end
+
+      it "returns :not_found for a correct id but unauthorized company" do
+        new_company = create(:company)
+        create(:group, company: new_company, id: 1000)
+
+        put :put_update, params: { id: 1000 }, as: :json
+
+        expect(response.status).to eq 404
+      end
+
+      it "returns 422 with incomplete request" do
+        put :put_update, params: {
+          id: 1,
+          members: []
+        }, as: :json
+
+        expect(response.status).to eq 422
+      end
+    end
+  end
+
+  describe "destroy" do
+    let(:company) { create(:company) }
+
+    context "when unauthorized" do
+      it "returns scim+json content type" do
+        delete :destroy, params: { id: 1 }, as: :json
+
+        expect(response.media_type).to eq "application/scim+json"
+      end
+
+      it "fails with no credentials" do
+        delete :destroy, params: { id: 1 }, as: :json
+
+        expect(response.status).to eq 401
+      end
+
+      it "fails with invalid credentials" do
+        request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials("unauthorized","123456")
+
+        delete :destroy, params: { id: 1 }, as: :json
+
+        expect(response.status).to eq 401
+      end
+    end
+
+    context "when authorized" do
+      let!(:group) { create(:group, id: 1, company: company) }
+
+      before :each do
+        http_login(company)
+      end
+
+      context "when Group destroy method is configured" do
+        before do
+          allow(ScimRails.config).to receive(:group_destroy_method).and_return(:destroy!)
+        end
+
+        it "returns empty response" do
+          delete :destroy, params: { id: 1 }, as: :json
+
+          expect(response.body).to be_empty
+        end
+
+        it "is successful with valid credentials" do
+          delete :destroy, params: { id: 1 }, as: :json
+
+          expect(response.status).to eq 204
+        end
+
+        it "returns :not_found for id that cannot be found" do
+          delete :destroy, params: { id: "fake_id" }, as: :json
+
+          expect(response.status).to eq 404
+        end
+
+        it "returns :not_found for a correct id but unauthorized company" do
+          new_company = create(:company)
+          create(:group, company: new_company, id: 1000)
+
+          delete :destroy, params: { id: 1000 }, as: :json
+
+          expect(response.status).to eq 404
+        end
+
+        it "successfully deletes Group" do
+          expect do
+            delete :destroy, params: { id: 1 }, as: :json
+          end.to change { company.groups.reload.count }.from(1).to(0)
+
+          expect(response.status).to eq 204
+        end
+      end
+
+      context "when Group destroy method is not configured" do
+        it "does not delete Group" do
+          allow(ScimRails.config).to receive(:group_destroy_method).and_return(nil)
+
+          expect do
+            delete :destroy, params: { id: 1 }, as: :json
+          end.not_to change { company.groups.reload.count }.from(1)
+
+          expect(response.status).to eq 501
+        end
+      end
+    end
+  end
+
+  def put_params(name: "Test Group", users: [])
+    {
+      id: 1,
+      displayName: name,
+      members: users.map { |user| { value: user.id.to_s, display: user.email } }
+    }
+  end
+end

--- a/spec/controllers/scim_rails/scim_groups_controller_spec.rb
+++ b/spec/controllers/scim_rails/scim_groups_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe ScimRails::ScimGroupsController, type: :controller do
@@ -24,7 +26,7 @@ RSpec.describe ScimRails::ScimGroupsController, type: :controller do
       it "fails with invalid credentials" do
         request.env["HTTP_AUTHORIZATION"] =
           ActionController::HttpAuthentication::Basic
-          .encode_credentials("unauthorized", "123456")
+            .encode_credentials("unauthorized", "123456")
 
         get :index, as: :json
 
@@ -54,7 +56,9 @@ RSpec.describe ScimRails::ScimGroupsController, type: :controller do
 
         get :index, as: :json
         response_body = JSON.parse(response.body)
-        expect(response_body.dig("schemas", 0)).to eq "urn:ietf:params:scim:api:messages:2.0:ListResponse"
+        expect(response_body.dig("schemas", 0)).to(
+          eq "urn:ietf:params:scim:api:messages:2.0:ListResponse"
+        )
         expect(response_body["totalResults"]).to eq 5
       end
 
@@ -73,7 +77,7 @@ RSpec.describe ScimRails::ScimGroupsController, type: :controller do
 
         get :index, params: {
           startIndex: 101,
-          count: 200,
+          count: 200
         }, as: :json
         response_body = JSON.parse(response.body)
         expect(response_body["totalResults"]).to eq 400
@@ -82,14 +86,16 @@ RSpec.describe ScimRails::ScimGroupsController, type: :controller do
       end
 
       it "paginates results by configurable scim_groups_list_order" do
-        allow(ScimRails.config).to receive(:scim_groups_list_order).and_return({ created_at: :desc })
+        allow(ScimRails.config).to(
+          receive(:scim_groups_list_order).and_return(created_at: :desc)
+        )
 
         create_list(:group, 400, company: company)
         expect(company.groups.first.id).to eq 1
 
         get :index, params: {
           startIndex: 1,
-          count: 10,
+          count: 10
         }, as: :json
         response_body = JSON.parse(response.body)
         expect(response_body["totalResults"]).to eq 400
@@ -125,7 +131,9 @@ RSpec.describe ScimRails::ScimGroupsController, type: :controller do
         }, as: :json
         expect(response.status).to eq 400
         response_body = JSON.parse(response.body)
-        expect(response_body.dig("schemas", 0)).to eq "urn:ietf:params:scim:api:messages:2.0:Error"
+        expect(response_body.dig("schemas", 0)).to(
+          eq "urn:ietf:params:scim:api:messages:2.0:Error"
+        )
       end
     end
   end
@@ -147,9 +155,9 @@ RSpec.describe ScimRails::ScimGroupsController, type: :controller do
       end
 
       it "fails with invalid credentials" do
-        request.env['HTTP_AUTHORIZATION'] =
+        request.env["HTTP_AUTHORIZATION"] =
           ActionController::HttpAuthentication::Basic
-          .encode_credentials("unauthorized", "123456")
+            .encode_credentials("unauthorized", "123456")
 
         get :show, params: { id: 1 }, as: :json
 
@@ -209,7 +217,9 @@ RSpec.describe ScimRails::ScimGroupsController, type: :controller do
       end
 
       it "fails with invalid credentials" do
-        request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials("unauthorized","123456")
+        request.env["HTTP_AUTHORIZATION"] =
+          ActionController::HttpAuthentication::Basic
+            .encode_credentials("unauthorized", "123456")
 
         post :create, as: :json
 
@@ -315,7 +325,9 @@ RSpec.describe ScimRails::ScimGroupsController, type: :controller do
       end
 
       it "fails with invalid credentials" do
-        request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials("unauthorized","123456")
+        request.env["HTTP_AUTHORIZATION"] =
+          ActionController::HttpAuthentication::Basic
+            .encode_credentials("unauthorized", "123456")
 
         put :put_update, params: { id: 1 }, as: :json
 
@@ -396,9 +408,9 @@ RSpec.describe ScimRails::ScimGroupsController, type: :controller do
       end
 
       it "fails with invalid credentials" do
-        request.env['HTTP_AUTHORIZATION'] =
+        request.env["HTTP_AUTHORIZATION"] =
           ActionController::HttpAuthentication::Basic
-          .encode_credentials("unauthorized", "123456")
+            .encode_credentials("unauthorized", "123456")
 
         delete :destroy, params: { id: 1 }, as: :json
 

--- a/spec/controllers/scim_rails/scim_groups_request_spec.rb
+++ b/spec/controllers/scim_rails/scim_groups_request_spec.rb
@@ -1,0 +1,64 @@
+require "spec_helper"
+
+RSpec.describe ScimRails::ScimGroupsController, type: :request do
+  let(:company) { create(:company) }
+  let(:credentials) { Base64::encode64("#{company.subdomain}:#{company.api_token}") }
+  let(:authorization) { "Basic #{credentials}" }
+
+  def post_request(content_type = "application/scim+json")
+    post "/scim/v2/Groups",
+         params: {
+           displayName: "Dummy Group",
+           members: []
+         }.to_json,
+         headers: {
+           'Authorization': authorization,
+           'Content-Type': content_type,
+         }
+  end
+
+  describe "Content-Type" do
+    it "accepts scim+json" do
+      expect(company.groups.count).to eq 0
+
+      post_request("application/scim+json")
+
+      expect(request.params).to include :displayName
+      expect(response.status).to eq 201
+      expect(response.media_type).to eq "application/scim+json"
+      expect(company.groups.count).to eq 1
+    end
+
+    it "can not parse unfamiliar content types" do
+      expect(company.groups.count).to eq 0
+
+      post_request("text/csv")
+
+      expect(request.params).not_to include :displayName
+      expect(response.status).to eq 422
+      expect(company.groups.count).to eq 0
+    end
+  end
+
+  context "OAuth Bearer Authorization" do
+    context "with valid token" do
+      let(:authorization) { "Bearer #{company.api_token}" }
+
+      it "supports OAuth bearer authorization and succeeds" do
+        expect { post_request }.to change(company.groups, :count).from(0).to(1)
+
+        expect(response.status).to eq 201
+      end
+    end
+
+    context "with invalid token" do
+      let(:authorization) { "Bearer #{SecureRandom.hex}" }
+
+      it "The request fails" do
+        expect { post_request }.not_to change(company.groups, :count)
+
+        expect(response.status).to eq 401
+      end
+    end
+  end
+end

--- a/spec/controllers/scim_rails/scim_groups_request_spec.rb
+++ b/spec/controllers/scim_rails/scim_groups_request_spec.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe ScimRails::ScimGroupsController, type: :request do
   let(:company) { create(:company) }
-  let(:credentials) { Base64::encode64("#{company.subdomain}:#{company.api_token}") }
+  let(:credentials) { Base64.encode64("#{company.subdomain}:#{company.api_token}") }
   let(:authorization) { "Basic #{credentials}" }
 
   def post_request(content_type = "application/scim+json")
@@ -12,8 +14,8 @@ RSpec.describe ScimRails::ScimGroupsController, type: :request do
            members: []
          }.to_json,
          headers: {
-           'Authorization': authorization,
-           'Content-Type': content_type,
+           Authorization: authorization,
+           'Content-Type': content_type
          }
   end
 

--- a/spec/controllers/scim_rails/scim_groups_request_spec.rb
+++ b/spec/controllers/scim_rails/scim_groups_request_spec.rb
@@ -4,7 +4,9 @@ require "spec_helper"
 
 RSpec.describe ScimRails::ScimGroupsController, type: :request do
   let(:company) { create(:company) }
-  let(:credentials) { Base64.encode64("#{company.subdomain}:#{company.api_token}") }
+  let(:credentials) do
+    Base64.encode64("#{company.subdomain}:#{company.api_token}")
+  end
   let(:authorization) { "Basic #{credentials}" }
 
   def post_request(content_type = "application/scim+json")

--- a/spec/controllers/scim_rails/scim_users_controller_spec.rb
+++ b/spec/controllers/scim_rails/scim_users_controller_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
       it "fails with invalid credentials" do
         request.env["HTTP_AUTHORIZATION"] =
           ActionController::HttpAuthentication::Basic
-            .encode_credentials("unauthorized", "123456")
+          .encode_credentials("unauthorized", "123456")
 
         get :index, as: :json
 
@@ -162,7 +162,7 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
       it "fails with invalid credentials" do
         request.env["HTTP_AUTHORIZATION"] =
           ActionController::HttpAuthentication::Basic
-            .encode_credentials("unauthorized", "123456")
+          .encode_credentials("unauthorized", "123456")
 
         get :show, params: { id: 1 }, as: :json
 
@@ -224,7 +224,7 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
       it "fails with invalid credentials" do
         request.env["HTTP_AUTHORIZATION"] =
           ActionController::HttpAuthentication::Basic
-            .encode_credentials("unauthorized", "123456")
+          .encode_credentials("unauthorized", "123456")
 
         post :create, as: :json
 
@@ -394,7 +394,7 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
       it "fails with invalid credentials" do
         request.env["HTTP_AUTHORIZATION"] =
           ActionController::HttpAuthentication::Basic
-            .encode_credentials("unauthorized", "123456")
+          .encode_credentials("unauthorized", "123456")
 
         put :put_update, params: { id: 1 }, as: :json
 
@@ -490,7 +490,7 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
       it "fails with invalid credentials" do
         request.env["HTTP_AUTHORIZATION"] =
           ActionController::HttpAuthentication::Basic
-            .encode_credentials("unauthorized", "123456")
+          .encode_credentials("unauthorized", "123456")
 
         patch :patch_update, params: patch_params(id: 1), as: :json
 
@@ -550,7 +550,10 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
         user = company.users.first.tap(&:archive!)
         expect(user.archived?).to eq true
 
-        patch :patch_update, params: patch_params(id: 1, active: true), as: :json
+        patch \
+          :patch_update,
+          params: patch_params(id: 1, active: true),
+          as: :json
 
         expect(response.status).to eq 200
         expect(company.users.count).to eq 1

--- a/spec/controllers/scim_rails/scim_users_controller_spec.rb
+++ b/spec/controllers/scim_rails/scim_users_controller_spec.rb
@@ -433,7 +433,7 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
       end
 
       it "returns :not_found for id that cannot be found" do
-        get :put_update, params: { id: "fake_id" }, as: :json
+        put :put_update, params: { id: "fake_id" }, as: :json
 
         expect(response.status).to eq 404
       end
@@ -442,7 +442,7 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
         new_company = create(:company)
         create(:user, company: new_company, id: 1000)
 
-        get :put_update, params: { id: 1000 }, as: :json
+        put :put_update, params: { id: 1000 }, as: :json
 
         expect(response.status).to eq 404
       end

--- a/spec/controllers/scim_rails/scim_users_controller_spec.rb
+++ b/spec/controllers/scim_rails/scim_users_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe ScimRails::ScimUsersController, type: :controller do
@@ -24,7 +26,7 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
       it "fails with invalid credentials" do
         request.env["HTTP_AUTHORIZATION"] =
           ActionController::HttpAuthentication::Basic
-          .encode_credentials("unauthorized","123456")
+            .encode_credentials("unauthorized", "123456")
 
         get :index, as: :json
 
@@ -73,7 +75,7 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
 
         get :index, params: {
           startIndex: 101,
-          count: 200,
+          count: 200
         }, as: :json
         response_body = JSON.parse(response.body)
         expect(response_body["totalResults"]).to eq 400
@@ -89,7 +91,7 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
 
         get :index, params: {
           startIndex: 1,
-          count: 10,
+          count: 10
         }, as: :json
         response_body = JSON.parse(response.body)
         expect(response_body["totalResults"]).to eq 400
@@ -141,7 +143,6 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
     end
   end
 
-
   describe "show" do
     let(:company) { create(:company) }
 
@@ -161,7 +162,7 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
       it "fails with invalid credentials" do
         request.env["HTTP_AUTHORIZATION"] =
           ActionController::HttpAuthentication::Basic
-          .encode_credentials("unauthorized","123456")
+            .encode_credentials("unauthorized", "123456")
 
         get :show, params: { id: 1 }, as: :json
 
@@ -204,7 +205,6 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
     end
   end
 
-
   describe "create" do
     let(:company) { create(:company) }
 
@@ -224,7 +224,7 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
       it "fails with invalid credentials" do
         request.env["HTTP_AUTHORIZATION"] =
           ActionController::HttpAuthentication::Basic
-          .encode_credentials("unauthorized","123456")
+            .encode_credentials("unauthorized", "123456")
 
         post :create, as: :json
 
@@ -362,7 +362,7 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
           emails: [
             {
               value: "test@example.com"
-            },
+            }
           ],
           active: "false"
         }, as: :json
@@ -374,7 +374,6 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
       end
     end
   end
-
 
   describe "put update" do
     let(:company) { create(:company) }
@@ -395,7 +394,7 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
       it "fails with invalid credentials" do
         request.env["HTTP_AUTHORIZATION"] =
           ActionController::HttpAuthentication::Basic
-          .encode_credentials("unauthorized","123456")
+            .encode_credentials("unauthorized", "123456")
 
         put :put_update, params: { id: 1 }, as: :json
 
@@ -462,7 +461,7 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
           emails: [
             {
               value: "test@example.com"
-            },
+            }
           ],
           active: "true"
         }, as: :json
@@ -471,7 +470,6 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
       end
     end
   end
-
 
   describe "patch update" do
     let(:company) { create(:company) }
@@ -492,7 +490,7 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
       it "fails with invalid credentials" do
         request.env["HTTP_AUTHORIZATION"] =
           ActionController::HttpAuthentication::Basic
-          .encode_credentials("unauthorized","123456")
+            .encode_credentials("unauthorized", "123456")
 
         patch :patch_update, params: patch_params(id: 1), as: :json
 
@@ -552,7 +550,7 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
         user = company.users.first.tap(&:archive!)
         expect(user.archived?).to eq true
 
-        patch :patch_update, params: patch_params(id: 1,  active: true), as: :json
+        patch :patch_update, params: patch_params(id: 1, active: true), as: :json
 
         expect(response.status).to eq 200
         expect(company.users.count).to eq 1
@@ -672,7 +670,7 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
       emails: [
         {
           value: "test@example.com"
-        },
+        }
       ],
       active: active
     }

--- a/spec/controllers/scim_rails/scim_users_controller_spec.rb
+++ b/spec/controllers/scim_rails/scim_users_controller_spec.rb
@@ -22,7 +22,9 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
       end
 
       it "fails with invalid credentials" do
-        request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials("unauthorized","123456")
+        request.env["HTTP_AUTHORIZATION"] =
+          ActionController::HttpAuthentication::Basic
+          .encode_credentials("unauthorized","123456")
 
         get :index, as: :json
 
@@ -157,7 +159,9 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
       end
 
       it "fails with invalid credentials" do
-        request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials("unauthorized","123456")
+        request.env["HTTP_AUTHORIZATION"] =
+          ActionController::HttpAuthentication::Basic
+          .encode_credentials("unauthorized","123456")
 
         get :show, params: { id: 1 }, as: :json
 
@@ -218,7 +222,9 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
       end
 
       it "fails with invalid credentials" do
-        request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials("unauthorized","123456")
+        request.env["HTTP_AUTHORIZATION"] =
+          ActionController::HttpAuthentication::Basic
+          .encode_credentials("unauthorized","123456")
 
         post :create, as: :json
 
@@ -387,7 +393,9 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
       end
 
       it "fails with invalid credentials" do
-        request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials("unauthorized","123456")
+        request.env["HTTP_AUTHORIZATION"] =
+          ActionController::HttpAuthentication::Basic
+          .encode_credentials("unauthorized","123456")
 
         put :put_update, params: { id: 1 }, as: :json
 
@@ -482,7 +490,9 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
       end
 
       it "fails with invalid credentials" do
-        request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials("unauthorized","123456")
+        request.env["HTTP_AUTHORIZATION"] =
+          ActionController::HttpAuthentication::Basic
+          .encode_credentials("unauthorized","123456")
 
         patch :patch_update, params: patch_params(id: 1), as: :json
 

--- a/spec/controllers/scim_rails/scim_users_request_spec.rb
+++ b/spec/controllers/scim_rails/scim_users_request_spec.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe ScimRails::ScimUsersController, type: :request do
   let(:company) { create(:company) }
-  let(:credentials) { Base64::encode64("#{company.subdomain}:#{company.api_token}") }
+  let(:credentials) { Base64.encode64("#{company.subdomain}:#{company.api_token}") }
   let(:authorization) { "Basic #{credentials}" }
 
   def post_request(content_type = "application/scim+json")
@@ -12,17 +14,17 @@ RSpec.describe ScimRails::ScimUsersController, type: :request do
          params: {
            name: {
              givenName: "New",
-             familyName: "User",
+             familyName: "User"
            },
            emails: [
              {
-               value: "new@example.com",
-             },
-           ],
+               value: "new@example.com"
+             }
+           ]
          }.to_json,
          headers: {
-           'Authorization': authorization,
-           'Content-Type': content_type,
+           Authorization: authorization,
+           'Content-Type': content_type
          }
   end
 

--- a/spec/controllers/scim_rails/scim_users_request_spec.rb
+++ b/spec/controllers/scim_rails/scim_users_request_spec.rb
@@ -4,7 +4,9 @@ require "spec_helper"
 
 RSpec.describe ScimRails::ScimUsersController, type: :request do
   let(:company) { create(:company) }
-  let(:credentials) { Base64.encode64("#{company.subdomain}:#{company.api_token}") }
+  let(:credentials) do
+    Base64.encode64("#{company.subdomain}:#{company.api_token}")
+  end
   let(:authorization) { "Basic #{credentials}" }
 
   def post_request(content_type = "application/scim+json")

--- a/spec/dummy/app/models/company.rb
+++ b/spec/dummy/app/models/company.rb
@@ -1,3 +1,4 @@
 class Company < ApplicationRecord
   has_many :users
+  has_many :groups
 end

--- a/spec/dummy/app/models/group.rb
+++ b/spec/dummy/app/models/group.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Group < ApplicationRecord
   belongs_to :company
   has_many :group_users

--- a/spec/dummy/app/models/group.rb
+++ b/spec/dummy/app/models/group.rb
@@ -1,0 +1,13 @@
+class Group < ApplicationRecord
+  belongs_to :company
+  has_many :group_users
+  has_many :users, through: :group_users
+
+  validates \
+    :name,
+    presence: true,
+    uniqueness: {
+      case_insensitive: true,
+      scope: :company
+    }
+end

--- a/spec/dummy/app/models/group_user.rb
+++ b/spec/dummy/app/models/group_user.rb
@@ -1,0 +1,4 @@
+class GroupUser < ApplicationRecord
+  belongs_to :group
+  belongs_to :user
+end

--- a/spec/dummy/app/models/group_user.rb
+++ b/spec/dummy/app/models/group_user.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class GroupUser < ApplicationRecord
   belongs_to :group
   belongs_to :user

--- a/spec/dummy/app/models/user.rb
+++ b/spec/dummy/app/models/user.rb
@@ -1,5 +1,7 @@
 class User < ApplicationRecord
   belongs_to :company
+  has_many :group_users
+  has_many :groups, through: :group_users
 
   validates \
     :first_name,

--- a/spec/dummy/config/initializers/scim_rails_config.rb
+++ b/spec/dummy/config/initializers/scim_rails_config.rb
@@ -1,11 +1,13 @@
 ScimRails.configure do |config|
   config.basic_auth_model = "Company"
   config.scim_users_model = "User"
+  config.scim_groups_model = "Group"
 
   config.basic_auth_model_searchable_attribute = :subdomain
   config.basic_auth_model_authenticatable_attribute = :api_token
   config.scim_users_scope = :users
   config.scim_users_list_order = :id
+  config.scim_groups_scope = :groups
 
   config.signing_algorithm = "HS256"
   config.signing_secret = "2d6806dd11c2fece2e81b8ca76dcb0062f5b08e28e3264e8ba1c44bbd3578b70"
@@ -52,5 +54,32 @@ ScimRails.configure do |config|
       },
     ],
     active: :unarchived?
+  }
+
+  config.queryable_group_attributes = {
+    displayName: :name
+  }
+
+  config.mutable_group_attributes = [
+    :name
+  ]
+
+  config.mutable_group_attributes_schema = {
+    displayName: :name
+  }
+
+  config.group_member_relation_attribute = :user_ids
+  config.group_member_relation_schema = { value: :user_ids }
+
+  config.group_schema = {
+    schemas: ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+    id: :id,
+    displayName: :name,
+    members: :users
+  }
+
+  config.group_abbreviated_schema = {
+    value: :id,
+    display: :name
   }
 end

--- a/spec/dummy/db/migrate/20210423075859_create_groups.rb
+++ b/spec/dummy/db/migrate/20210423075859_create_groups.rb
@@ -1,4 +1,4 @@
-class CreateGroups < ActiveRecord::Migration[6.1]
+class CreateGroups < ActiveRecord::Migration[5.0]
   def change
     create_table :groups do |t|
       t.string :name, null: false

--- a/spec/dummy/db/migrate/20210423075859_create_groups.rb
+++ b/spec/dummy/db/migrate/20210423075859_create_groups.rb
@@ -1,0 +1,10 @@
+class CreateGroups < ActiveRecord::Migration[6.1]
+  def change
+    create_table :groups do |t|
+      t.string :name, null: false
+      t.references :company, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/spec/dummy/db/migrate/20210423075950_create_group_users.rb
+++ b/spec/dummy/db/migrate/20210423075950_create_group_users.rb
@@ -1,0 +1,10 @@
+class CreateGroupUsers < ActiveRecord::Migration[6.1]
+  def change
+    create_table :group_users do |t|
+      t.references :group, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/spec/dummy/db/migrate/20210423075950_create_group_users.rb
+++ b/spec/dummy/db/migrate/20210423075950_create_group_users.rb
@@ -1,4 +1,4 @@
-class CreateGroupUsers < ActiveRecord::Migration[6.1]
+class CreateGroupUsers < ActiveRecord::Migration[5.0]
   def change
     create_table :group_users do |t|
       t.references :group, null: false, foreign_key: true

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -2,32 +2,52 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# Note that this schema.rb definition is the authoritative source for your
-# database schema. If you need to create the application database on another
-# system, you should be using db:schema:load, not running all the migrations
-# from scratch. The latter is a flawed and unsustainable approach (the more migrations
-# you'll amass, the slower it'll run and the greater likelihood for issues).
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181206184313) do
+ActiveRecord::Schema.define(version: 2021_04_23_075950) do
 
   create_table "companies", force: :cascade do |t|
-    t.string   "name",       null: false
-    t.string   "subdomain",  null: false
-    t.string   "api_token",  null: false
+    t.string "name", null: false
+    t.string "subdomain", null: false
+    t.string "api_token", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "users", force: :cascade do |t|
-    t.string   "first_name",  null: false
-    t.string   "last_name",   null: false
-    t.string   "email",       null: false
-    t.integer  "company_id"
-    t.datetime "archived_at"
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
+  create_table "group_users", force: :cascade do |t|
+    t.integer "group_id", null: false
+    t.integer "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["group_id"], name: "index_group_users_on_group_id"
+    t.index ["user_id"], name: "index_group_users_on_user_id"
   end
 
+  create_table "groups", force: :cascade do |t|
+    t.string "name", null: false
+    t.integer "company_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["company_id"], name: "index_groups_on_company_id"
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "first_name", null: false
+    t.string "last_name", null: false
+    t.string "email", null: false
+    t.integer "company_id"
+    t.datetime "archived_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_foreign_key "group_users", "groups"
+  add_foreign_key "group_users", "users"
+  add_foreign_key "groups", "companies"
 end

--- a/spec/factories/group.rb
+++ b/spec/factories/group.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :group do
+    company
+
+    sequence(:name) { |i| "Test Group ##{i}" }
+
+    trait :with_users do
+      users { create_list(:user) }
+    end
+  end
+end


### PR DESCRIPTION
## Why?

Support for SCIM user Groups is currently missing
lessonly/scim_rails#46 

## What?

* add options to configure how to handle Groups
* add API endpoints to deal with Groups

## Caveats

* The PUT updating of Group `members` is a bit hacky.

## Testing Notes

I'm developing this using Okta as well so there shouldn't be anything extra to set up.

- [x] sync Groups
- [x] update Group name (or similar mapped attribute)
- [x] update Group membership
- [x] delete Group (delete after unlink)

## Alternatives Considered

There is the option to build a more complete User association handling as outlined in lessonly/scim_rails#39, but I felt that's a bit too big to chew for this purpose.