### PR TITLE
Add patch request parser

### DIFF
--- a/app/controllers/scim_rails/scim_users_controller.rb
+++ b/app/controllers/scim_rails/scim_users_controller.rb
@@ -62,6 +62,10 @@ module ScimRails
     # This will work just fine for Okta but is not SCIM compliant.
     def patch_update
       user = @company.public_send(ScimRails.config.scim_users_scope).find(params[:id])
+      patch = ScimPatch.new(params, ScimRails.config.mutable_user_attributes_schema)
+      # patch.apply(user)
+      # user.save
+
       update_status(user)
       json_scim_response(object: user)
     end

--- a/app/controllers/scim_rails/scim_users_controller.rb
+++ b/app/controllers/scim_rails/scim_users_controller.rb
@@ -62,7 +62,7 @@ module ScimRails
     # This will work just fine for Okta but is not SCIM compliant.
     def patch_update
       user = @company.public_send(ScimRails.config.scim_users_scope).find(params[:id])
-      patch = ScimPatch.new(params, ScimRails.config.mutable_user_attributes_schema)
+      # patch = ScimPatch.new(params, ScimRails.config.mutable_user_attributes_schema)
       # patch.apply(user)
       # user.save
 

--- a/app/libraries/scim_patch.rb
+++ b/app/libraries/scim_patch.rb
@@ -17,7 +17,7 @@ class ScimPatch
   # WIP
   def apply(model)
     @operations.each do |operation|
-      operation.update(model)
+      operation.apply(model)
     end
     return model
   end

--- a/app/libraries/scim_patch.rb
+++ b/app/libraries/scim_patch.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class ScimPatch
+  attr_accessor :operations
+
+  def initialize(params, mutable_attributes_schema)
+    # FIXME: raise proper error.
+    unless params['schemas'] == ['urn:ietf:params:scim:api:messages:2.0:PatchOp']
+      raise StandardError 
+    end
+
+    @operations = params["Operations"].map do |operation|
+      ScimPatchOperation.new(operation["op"], operation["path"], operation["value"], mutable_attributes_schema)
+    end
+  end
+
+  # WIP
+  def apply(model)
+    @operations.each do |operation|
+      operation.update(model)
+    end
+    return model
+  end
+end

--- a/app/libraries/scim_patch.rb
+++ b/app/libraries/scim_patch.rb
@@ -1,13 +1,12 @@
 # frozen_string_literal: true
 
+# Parse PATCH request
 class ScimPatch
   attr_accessor :operations
 
   def initialize(params, mutable_attributes_schema)
     # FIXME: raise proper error.
-    unless params['schemas'] == ['urn:ietf:params:scim:api:messages:2.0:PatchOp']
-      raise StandardError 
-    end
+    raise StandardError unless params["schemas"] == ["urn:ietf:params:scim:api:messages:2.0:PatchOp"]
 
     @operations = params["Operations"].map do |operation|
       ScimPatchOperation.new(operation["op"], operation["path"], operation["value"], mutable_attributes_schema)
@@ -19,6 +18,6 @@ class ScimPatch
     @operations.each do |operation|
       operation.apply(model)
     end
-    return model
+    model
   end
 end

--- a/app/libraries/scim_patch_operation.rb
+++ b/app/libraries/scim_patch_operation.rb
@@ -44,13 +44,9 @@ class ScimPatchOperation
     #     ],
     #   }
     #
-    #   Library ignores [type eq "work"] and dig(:emails, 0, :value)
-    dig_keys = path.gsub(/\[(.+?)\]/, ".0").split(".").map do |element|
-      Integer(element)
-    rescue StandardError
-      element.to_sym
-    end
-
+    #   Library ignores filter conditions (like [type eq "work"])
+    #   and always uses the first element of the array
+    dig_keys = path.gsub(/\[(.+?)\]/, ".0").split(".").map { |step| step == "0" ? 0 : step.to_sym }
     mutable_attributes_schema.dig(*dig_keys)
   end
 end

--- a/app/libraries/scim_patch_operation.rb
+++ b/app/libraries/scim_patch_operation.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+class ScimPatchOperation
+  attr_accessor :op, :path_scim, :path_sp, :value
+
+  def initialize(op, path, value, mutable_attributes_schema)      
+    # FIXME: Raise proper Error
+    raise StandardError unless op.in? ['Add', 'Replace', 'Remove']
+
+    # No path is not supported.
+    # FIXME: Raise proper Error
+    raise StandardError if path.nil?
+
+    @op = op.downcase.to_sym
+    @path_scim = path
+
+    # For now, library does not support model which has many email addresses.
+    @path_sp = if path.start_with?('emails[')
+      mutable_attributes_schema.dig(:emails, 0, :value)
+    elsif path.include?('.')
+      mutable_attributes_schema.dig(*path.split(/\./).map(&:to_sym))
+    else
+      mutable_attributes_schema[path.to_sym]
+    end
+    
+    @value = value
+  end
+
+  # WIP
+  def apply(model)
+    case @op
+    when :add
+      model.update(@path_sp, @value)
+    when :replace
+      model.update(@path_sp, @value)
+    when :remove
+      model.update(@path_sp, nil)
+    end
+  end
+end

--- a/spec/libraries/scim_patch_operation_spec.rb
+++ b/spec/libraries/scim_patch_operation_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe ScimPatchOperation do
+
+  let(:op) { 'Replace' }
+  let(:path) { 'userName' }
+  let(:value) { 'taro.suzuki' }
+  let(:mutable_attributes_schema) {
+    {
+      userName: :name,
+      displayName: :display_name,
+      emails: [
+        {
+          value: :email
+        }
+      ],
+      name: {
+        familyName: :family_name,
+        givenName: :given_name
+      }
+    }
+  }
+  let(:operation) {
+    described_class.new(
+      op,
+      path,
+      value,
+      mutable_attributes_schema
+    )
+  }
+  describe '#initialize' do
+    context 'replace single attribute' do
+      it {
+        expect(operation.op).to eq :replace
+        expect(operation.path_scim).to eq path
+        expect(operation.path_sp).to eq :name
+        expect(operation.value).to eq value
+      }
+    end
+
+    context 'add single attribute' do
+      let(:op) { 'Add' }
+      it {
+        expect(operation.op).to eq :add
+        expect(operation.path_scim).to eq path
+        expect(operation.path_sp).to eq :name
+        expect(operation.value).to eq value
+      }
+    end
+
+    context 'remove single attribute' do
+      let(:op) { 'Remove' }
+      it {
+        expect(operation.op).to eq :remove
+        expect(operation.path_scim).to eq path
+        expect(operation.path_sp).to eq :name
+        expect(operation.value).to eq value
+      }
+    end
+
+    context 'replace email address' do
+      let(:path) { 'emails[type eq "work"].value' }
+      let(:value) { 'taro.suzuki@example.com' }
+      it {
+        expect(operation.op).to eq :replace
+        expect(operation.path_scim).to eq path
+        expect(operation.path_sp).to eq :email
+        expect(operation.value).to eq value
+      }
+    end
+
+    context 'replace name.familyName' do
+      let(:path) { 'name.familyName' }
+      let(:value) { 'Suzuki' }
+      it {
+        expect(operation.op).to eq :replace
+        expect(operation.path_scim).to eq path
+        expect(operation.path_sp).to eq :family_name
+        expect(operation.value).to eq value
+      }
+    end
+  end
+
+end

--- a/spec/libraries/scim_patch_spec.rb
+++ b/spec/libraries/scim_patch_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe ScimPatch do
+
+  let(:params) {
+    {
+      'schemas' => ['urn:ietf:params:scim:api:messages:2.0:PatchOp'],
+      'Operations' => [
+        {
+          'op' => 'Replace',
+          'path' => 'userName',
+          'value' => 'taro.suzuki'
+        },
+        {
+          'op' =>  'Replace',
+          'path' => 'emails[type eq "work"].value',
+          'value' => 'taro.suzuki@example.com'
+        },
+        {
+          'op' => 'Replace',
+          'path' => 'name.familyName',
+          'value' => 'Suzuki'
+        }
+      ]
+    }
+  }
+
+  let(:mutable_attributes_schema) {
+    {
+      userName: :name,
+      displayName: :display_name,
+      emails: [
+        {
+          value: :email
+        }
+      ],
+      name: {
+        familyName: :family_name,
+        givenName: :given_name
+      }
+    }
+  }
+
+  let(:patch) { described_class.new(params, mutable_attributes_schema) }
+
+  describe '#initialize' do
+    it {
+      expect(patch.operations[0].op).to eq :replace
+      expect(patch.operations[0].path_scim).to eq 'userName'
+      expect(patch.operations[0].path_sp).to eq :name
+      expect(patch.operations[0].value).to eq 'taro.suzuki'
+
+      expect(patch.operations[1].op).to eq :replace
+      expect(patch.operations[1].path_scim).to eq 'emails[type eq "work"].value'
+      expect(patch.operations[1].path_sp).to eq :email
+      expect(patch.operations[1].value).to eq 'taro.suzuki@example.com'
+
+      expect(patch.operations[2].op).to eq :replace
+      expect(patch.operations[2].path_scim).to eq 'name.familyName'
+      expect(patch.operations[2].path_sp).to eq :family_name
+      expect(patch.operations[2].value).to eq 'Suzuki'
+    }
+  end
+
+  # describe '#update' do
+    # create user by factory bot
+    # patch.update(user)
+  # end
+
+end


### PR DESCRIPTION
## Why?

Azure AD can not update User/Group data, because it send not PUT request but PATCH request.

## What?

Add PATCH parser.
Updating model has not been implemented yet.
