### PR TITLE
Update to 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # v0.5.0 06-12-2021
 
-- [User patch request for Azure AD is now supported](https://github.com/StudistCorporation/scimaenaga/pull/9)
+- [User patch request for Azure AD is now partial supported](https://github.com/StudistCorporation/scimaenaga/pull/9)
 
 # v0.4.1 22-11-2021
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # v0.5.0 06-12-2021
 
-- [User patch request for Azure AD is now partial supported](https://github.com/StudistCorporation/scimaenaga/pull/9)
+- [User patch request for Azure AD is now partially supported](https://github.com/StudistCorporation/scimaenaga/pull/9)
 
 # v0.4.1 22-11-2021
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Upcoming Release
 
+# v0.5.0 06-12-2021
+
+- [User patch request for Azure AD is now supported](https://github.com/StudistCorporation/scimaenaga/pull/9)
+
+# v0.4.1 22-11-2021
+
+- [Release as Scimaenaga](https://github.com/StudistCorporation/scimaenaga/pull/3)
+
 # v0.4.0 26-03-2021
 
 - [Rail 6.1 is now supported](https://github.com/lessonly/scim_rails/pull/41)

--- a/lib/scim_rails/version.rb
+++ b/lib/scim_rails/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ScimRails
-  VERSION = "0.4.1"
+  VERSION = "0.5.0"
 end


### PR DESCRIPTION
## Why?

User patch request for Azure AD is now partially supported.

## What?

- Update from 0.4.1 to 0.5.0
- Update change log
