### PR TITLE
Enable to query by emails

### DIFF
--- a/app/models/scim_rails/scim_query_parser.rb
+++ b/app/models/scim_rails/scim_query_parser.rb
@@ -4,7 +4,6 @@ module ScimRails
   class ScimQueryParser
     attr_accessor :query_elements, :query_attributes
 
-    # emails[type eq \"work\"].value eq \"taro@example.com\"
     def initialize(query_string, queryable_attributes)
       self.query_elements = query_string.gsub(/\[(.+?)\]/, ".0").split
       self.query_attributes = queryable_attributes

--- a/app/models/scim_rails/scim_query_parser.rb
+++ b/app/models/scim_rails/scim_query_parser.rb
@@ -4,8 +4,9 @@ module ScimRails
   class ScimQueryParser
     attr_accessor :query_elements, :query_attributes
 
+    # emails[type eq \"work\"].value eq \"taro@example.com\"
     def initialize(query_string, queryable_attributes)
-      self.query_elements = query_string.split
+      self.query_elements = query_string.gsub(/\[(.+?)\]/, ".0").split
       self.query_attributes = queryable_attributes
     end
 
@@ -13,9 +14,11 @@ module ScimRails
       attribute = query_elements[0]
       raise ScimRails::ExceptionHandler::InvalidQuery if attribute.blank?
 
-      attribute = attribute.to_sym
+      dig_keys = attribute.split(".").map do |step|
+        step == "0" ? 0 : step.to_sym
+      end
 
-      mapped_attribute = query_attributes[attribute]
+      mapped_attribute = query_attributes.dig(*dig_keys)
       raise ScimRails::ExceptionHandler::InvalidQuery if mapped_attribute.blank?
 
       mapped_attribute

--- a/spec/models/scim_query_parser_spec.rb
+++ b/spec/models/scim_query_parser_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe ScimRails::ScimQueryParser do
+
+  let(:query_string) { 'userName eq "taro"' }
+  let(:queryable_attributes) {
+    {
+      userName: :name,
+      emails: [
+        {
+          value: :email
+        }
+      ]
+    }
+  }
+  let(:parser) { described_class.new(query_string, queryable_attributes) }
+
+  describe '#attribute' do
+    context 'userName' do
+      it { expect(parser.attribute).to eq :name }
+    end
+
+    context 'emails[type eq "work"].value' do
+      let(:query_string) { 'emails[type eq "work"].value eq "taro@example.com"' }
+      it { expect(parser.attribute).to eq :email }
+    end
+  end
+end


### PR DESCRIPTION
## Why?

When configure Azure AD to query user by emails[type eq "work"] , provisioning end up with failure.

## What?

Fix ScimQueryParser.

Query `emails[type eq "work"].value eq "taro@example.com"` is parsed as `emails[0].value eq "taro@example.com"`.
For now, it just ignores [type eq "work"].