### PR TITLE
Update to 0.6.0 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Upcoming Release
 
+# v0.6.0 20-12-2021
+
+- [Group patch request is now partially supported (for Azure AD)](https://github.com/StudistCorporation/scimaenaga/pull/14)
+
 # v0.5.0 06-12-2021
 
 - [User patch request for Azure AD is now partially supported](https://github.com/StudistCorporation/scimaenaga/pull/9)

--- a/lib/scim_rails/version.rb
+++ b/lib/scim_rails/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ScimRails
-  VERSION = "0.5.0"
+  VERSION = '0.6.0'
 end


### PR DESCRIPTION
## Why?

Group patch request is now partially supported. (for Azure AD)

## What?

- Update from 0.5.0 to 0.6.0
- Update change log
