### PR TITLE
Update to 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Upcoming Release
 
+# v0.6.1 18-01-2022
+
+- [User deprovisioning/reprovisioning is now supoorted (for Azure AD)](https://github.com/StudistCorporation/scimaenaga/pull/17)
+
 # v0.6.0 20-12-2021
 
 - [Group patch request is now partially supported (for Azure AD)](https://github.com/StudistCorporation/scimaenaga/pull/14)
@@ -18,6 +22,5 @@
 
 # v0.3.1 8-06-2020
 
-- [Any unhandled error is now logged](https://github.com/lessonly/scim_rails/pull/27
-) to the configured rails logger by default. You can also now supply a custom callable that will be used to handle those exceptions instead. 
+- [Any unhandled error is now logged](https://github.com/lessonly/scim_rails/pull/27) to the configured rails logger by default. You can also now supply a custom callable that will be used to handle those exceptions instead.
 - [Fix a bug](https://github.com/lessonly/scim_rails/pull/30) where an exception was raised when the patch endpoint receive a malformed or enexpected request.

--- a/lib/scim_rails/version.rb
+++ b/lib/scim_rails/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ScimRails
-  VERSION = '0.6.0'
+  VERSION = '0.6.1'
 end


### PR DESCRIPTION
# Why?
User deprovisioning/reprovisioning is now supoorted (for Azure AD)

# What?
Update from 0.6.0 to 0.6.1
Update change log