### PR TITLE
Unify user id to string

### DIFF
--- a/app/libraries/scim_patch_operation.rb
+++ b/app/libraries/scim_patch_operation.rb
@@ -78,9 +78,9 @@ class ScimPatchOperation
       return value if path != 'active'
 
       case value
-      when 'true', 'True' then
+      when 'true', 'True'
         return true
-      when 'false', 'False' then
+      when 'false', 'False'
         return false
       else
         return value

--- a/app/libraries/scim_patch_operation.rb
+++ b/app/libraries/scim_patch_operation.rb
@@ -22,7 +22,7 @@ class ScimPatchOperation
   def save(model)
     if @path_scim == 'members' # Only members are supported for value is an array
       update_member_ids = @value.map do |v|
-        v[ScimRails.config.group_member_relation_schema.keys.first]
+        v[ScimRails.config.group_member_relation_schema.keys.first].to_s
       end
 
       current_member_ids = model

--- a/app/libraries/scim_patch_operation.rb
+++ b/app/libraries/scim_patch_operation.rb
@@ -26,7 +26,7 @@ class ScimPatchOperation
       end
 
       current_member_ids = model
-                           .public_send(ScimRails.config.group_member_relation_attribute)
+                           .public_send(ScimRails.config.group_member_relation_attribute).map(&:to_s)
       case @op
       when :add
         member_ids = current_member_ids.concat(update_member_ids)

--- a/spec/controllers/scim_rails/scim_groups_controller_spec.rb
+++ b/spec/controllers/scim_rails/scim_groups_controller_spec.rb
@@ -427,7 +427,7 @@ RSpec.describe ScimRails::ScimGroupsController, type: :controller do
 
       it 'can add Users from a Group' do
         expect do
-          patch :patch_update, params: patch_params(user_id: user2.id.to_s), as: :json
+          patch :patch_update, params: patch_params(user_id: user2.id), as: :json
         end.to change { group.reload.users }.from([user1]).to([user1, user2])
 
         expect(response.status).to eq 200
@@ -438,7 +438,7 @@ RSpec.describe ScimRails::ScimGroupsController, type: :controller do
         user2 = create(:user, company: company, groups: [group])
 
         expect do
-          put :patch_update, params: patch_params(user_id: user2.id.to_s, op: 'Remove'),
+          put :patch_update, params: patch_params(user_id: user2.id, op: 'Remove'),
                              as: :json
         end.to change { group.reload.users }.from([user1, user2]).to([user1])
 

--- a/spec/controllers/scim_rails/scim_groups_controller_spec.rb
+++ b/spec/controllers/scim_rails/scim_groups_controller_spec.rb
@@ -427,7 +427,7 @@ RSpec.describe ScimRails::ScimGroupsController, type: :controller do
 
       it 'can add Users from a Group' do
         expect do
-          patch :patch_update, params: patch_params(user_id: user2.id), as: :json
+          patch :patch_update, params: patch_params(user_id: user2.id.to_s), as: :json
         end.to change { group.reload.users }.from([user1]).to([user1, user2])
 
         expect(response.status).to eq 200

--- a/spec/controllers/scim_rails/scim_groups_controller_spec.rb
+++ b/spec/controllers/scim_rails/scim_groups_controller_spec.rb
@@ -438,7 +438,7 @@ RSpec.describe ScimRails::ScimGroupsController, type: :controller do
         user2 = create(:user, company: company, groups: [group])
 
         expect do
-          put :patch_update, params: patch_params(user_id: user2.id, op: 'Remove'),
+          put :patch_update, params: patch_params(user_id: user2.id.to_s, op: 'Remove'),
                              as: :json
         end.to change { group.reload.users }.from([user1, user2]).to([user1])
 


### PR DESCRIPTION
## Why?

The addition / removal of users to the group could not be handled correctly, because the difference between the user_id type of the number and the string.

## What?

Unify user_id to string.

