### PR TITLE
Update to 0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # v0.6.2 27-01-2022
 
-- [Fix a bug](https://github.com/StudistCorporation/scimaenaga/pull/22)
+- [Fix a bug](https://github.com/StudistCorporation/scimaenaga/pull/22) thet the addition / removal of users to the group could not be handled correctly.
 
 # v0.6.1 18-01-2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Upcoming Release
 
+# v0.6.2 27-01-2022
+
+- [Fix a bug](https://github.com/StudistCorporation/scimaenaga/pull/22)
+
 # v0.6.1 18-01-2022
 
 - [User deprovisioning/reprovisioning is now supoorted (for Azure AD)](https://github.com/StudistCorporation/scimaenaga/pull/17)

--- a/lib/scim_rails/version.rb
+++ b/lib/scim_rails/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ScimRails
-  VERSION = '0.6.1'
+  VERSION = '0.6.2'
 end


### PR DESCRIPTION
# Why?
Fix a bug thet the addition / removal of users to the group could not be handled correctly. (https://github.com/StudistCorporation/scimaenaga/pull/22)

# What?
Update from 0.6.1 to 0.6.2
Update change log