### PR TITLE
Accept member remove by filter

### DIFF
--- a/app/libraries/scim_patch_operation_group.rb
+++ b/app/libraries/scim_patch_operation_group.rb
@@ -13,26 +13,8 @@ class ScimPatchOperationGroup < ScimPatchOperation
   #
   # This format will have to be supported.
   def save(model)
-    if @path_scim[:attribute] == 'members' # Only members are supported for value is an array
-      update_member_ids = @value.map do |v|
-        v[ScimRails.config.group_member_relation_schema.keys.first].to_s
-      end
-
-      current_member_ids = model.public_send(
-        ScimRails.config.group_member_relation_attribute
-      ).map(&:to_s)
-      case @op
-      when 'add'
-        member_ids = current_member_ids.concat(update_member_ids)
-      when 'replace'
-        member_ids = current_member_ids.concat(update_member_ids)
-      when 'remove'
-        member_ids = current_member_ids - update_member_ids
-      end
-
-      # Only the member addition process is saved by each ids
-      model.public_send("#{ScimRails.config.group_member_relation_attribute}=",
-                        member_ids.uniq)
+    if @path_scim[:attribute] == 'members'
+      save_members(model)
       return
     end
 
@@ -45,6 +27,52 @@ class ScimPatchOperationGroup < ScimPatchOperation
   end
 
   private
+
+    def save_members(model)
+      current_member_ids = model.public_send(member_relation_attribute).map(&:to_s)
+
+      case @op
+      when 'add'
+        member_ids = add_member_ids(current_member_ids)
+      when 'replace'
+        member_ids = replace_member_ids
+      when 'remove'
+        member_ids = remove_member_ids(current_member_ids)
+      end
+
+      model.public_send("#{member_relation_attribute}=", member_ids.uniq)
+    end
+
+    def add_member_ids(current_member_ids)
+      current_member_ids.concat(member_ids_from_value)
+    end
+
+    def replace_member_ids
+      member_ids_from_value
+    end
+
+    def remove_member_ids(current_member_ids)
+      removed_member_ids = if member_ids_from_value.present?
+                             member_ids_from_value
+                           else
+                             [member_id_from_filter]
+                           end
+      current_member_ids - removed_member_ids
+    end
+
+    def member_ids_from_value
+      @member_ids_from_value ||= @value&.map do |v|
+        v['value'].to_s
+      end
+    end
+
+    def member_id_from_filter
+      @path_scim.dig(:filter, :parameter)
+    end
+
+    def member_relation_attribute
+      ScimRails.config.group_member_relation_attribute
+    end
 
     def validate(_op, _path, _value)
       return

--- a/app/libraries/scim_patch_operation_group.rb
+++ b/app/libraries/scim_patch_operation_group.rb
@@ -2,16 +2,6 @@
 
 class ScimPatchOperationGroup < ScimPatchOperation
 
-  # TODO: When feature flag is specified,
-  #       Azure AD sends member remove request as follows:
-  # "Operations": [
-  #   {
-  #       "op": "remove",
-  #       "path": "members[value eq \"7f4bc1a3-285e-48ae-8202-5accb43efb0e\"]"
-  #   }
-  # ]
-  #
-  # This format will have to be supported.
   def save(model)
     if @path_scim[:attribute] == 'members'
       save_members(model)

--- a/spec/libraries/scim_patch_operation_group_spec.rb
+++ b/spec/libraries/scim_patch_operation_group_spec.rb
@@ -22,146 +22,144 @@ describe ScimPatchOperationGroup do
       value
     )
   end
-  describe '#initialize' do
-    context 'replace displayName' do
-      it {
-        allow(ScimRails.config).to(
-          receive(:mutable_group_attributes_schema).and_return(mutable_attributes_schema)
-        )
-        allow(ScimRails.config).to(
-          receive(:group_member_relation_attribute).and_return(group_member_relation_attribute)
-        )
-        expect(operation.op).to eq 'replace'
-        expect(operation.path_scim).to eq(attribute: path, rest_path: [])
-        expect(operation.path_sp).to eq :name
-        expect(operation.value).to eq value
+  context 'replace displayName' do
+    it {
+      allow(ScimRails.config).to(
+        receive(:mutable_group_attributes_schema).and_return(mutable_attributes_schema)
+      )
+      allow(ScimRails.config).to(
+        receive(:group_member_relation_attribute).and_return(group_member_relation_attribute)
+      )
+      expect(operation.op).to eq 'replace'
+      expect(operation.path_scim).to eq(attribute: path, rest_path: [])
+      expect(operation.path_sp).to eq :name
+      expect(operation.value).to eq value
 
-        operation.save(group)
-        expect(group.name).to eq value
-      }
-    end
+      operation.save(group)
+      expect(group.name).to eq value
+    }
+  end
 
-    context 'add displayName' do
-      let(:op) { 'add' }
-      it {
-        allow(ScimRails.config).to(
-          receive(:mutable_group_attributes_schema).and_return(mutable_attributes_schema)
-        )
-        allow(ScimRails.config).to(
-          receive(:group_member_relation_attribute).and_return(group_member_relation_attribute)
-        )
-        expect(operation.op).to eq 'add'
-        expect(operation.path_scim).to eq(attribute: path, rest_path: [])
-        expect(operation.path_sp).to eq :name
-        expect(operation.value).to eq value
+  context 'add displayName' do
+    let(:op) { 'add' }
+    it {
+      allow(ScimRails.config).to(
+        receive(:mutable_group_attributes_schema).and_return(mutable_attributes_schema)
+      )
+      allow(ScimRails.config).to(
+        receive(:group_member_relation_attribute).and_return(group_member_relation_attribute)
+      )
+      expect(operation.op).to eq 'add'
+      expect(operation.path_scim).to eq(attribute: path, rest_path: [])
+      expect(operation.path_sp).to eq :name
+      expect(operation.value).to eq value
 
-        operation.save(group)
-        expect(group.name).to eq value
-      }
-    end
+      operation.save(group)
+      expect(group.name).to eq value
+    }
+  end
 
-    context 'remove displayName' do
-      let(:op) { 'remove' }
-      it {
-        allow(ScimRails.config).to(
-          receive(:mutable_group_attributes_schema).and_return(mutable_attributes_schema)
-        )
-        allow(ScimRails.config).to(
-          receive(:group_member_relation_attribute).and_return(group_member_relation_attribute)
-        )
-        expect(operation.op).to eq 'remove'
-        expect(operation.path_scim).to eq(attribute: path, rest_path: [])
-        expect(operation.path_sp).to eq :name
-        expect(operation.value).to eq value
+  context 'remove displayName' do
+    let(:op) { 'remove' }
+    it {
+      allow(ScimRails.config).to(
+        receive(:mutable_group_attributes_schema).and_return(mutable_attributes_schema)
+      )
+      allow(ScimRails.config).to(
+        receive(:group_member_relation_attribute).and_return(group_member_relation_attribute)
+      )
+      expect(operation.op).to eq 'remove'
+      expect(operation.path_scim).to eq(attribute: path, rest_path: [])
+      expect(operation.path_sp).to eq :name
+      expect(operation.value).to eq value
 
-        operation.save(group)
-        expect(group.name).to eq nil
-      }
-    end
+      operation.save(group)
+      expect(group.name).to eq nil
+    }
+  end
 
-    context 'add member' do
-      let(:op) { 'add' }
-      let(:path) { 'members' }
-      let(:value) { [{ 'value' => user3.id.to_s }, { 'value' => user4.id.to_s }] }
-      it {
-        allow(ScimRails.config).to(
-          receive(:mutable_group_attributes_schema).and_return(mutable_attributes_schema)
-        )
-        allow(ScimRails.config).to(
-          receive(:group_member_relation_attribute).and_return(group_member_relation_attribute)
-        )
-        expect(operation.op).to eq 'add'
-        expect(operation.path_scim).to eq(attribute: 'members', rest_path: [])
-        expect(operation.path_sp).to eq :user_ids
-        expect(operation.value).to eq value
+  context 'add member' do
+    let(:op) { 'add' }
+    let(:path) { 'members' }
+    let(:value) { [{ 'value' => user3.id.to_s }, { 'value' => user4.id.to_s }] }
+    it {
+      allow(ScimRails.config).to(
+        receive(:mutable_group_attributes_schema).and_return(mutable_attributes_schema)
+      )
+      allow(ScimRails.config).to(
+        receive(:group_member_relation_attribute).and_return(group_member_relation_attribute)
+      )
+      expect(operation.op).to eq 'add'
+      expect(operation.path_scim).to eq(attribute: 'members', rest_path: [])
+      expect(operation.path_sp).to eq :user_ids
+      expect(operation.value).to eq value
 
-        operation.save(group)
-        expect(group.users).to eq [user1, user2, user3, user4]
-      }
-    end
+      operation.save(group)
+      expect(group.users).to eq [user1, user2, user3, user4]
+    }
+  end
 
-    context 'replace member' do
-      let(:op) { 'replace' }
-      let(:path) { 'members' }
-      let(:value) { [{ 'value' => user3.id.to_s }, { 'value' => user4.id.to_s }] }
-      it {
-        allow(ScimRails.config).to(
-          receive(:mutable_group_attributes_schema).and_return(mutable_attributes_schema)
-        )
-        allow(ScimRails.config).to(
-          receive(:group_member_relation_attribute).and_return(group_member_relation_attribute)
-        )
-        expect(operation.op).to eq 'replace'
-        expect(operation.path_scim).to eq(attribute: 'members', rest_path: [])
-        expect(operation.path_sp).to eq :user_ids
-        expect(operation.value).to eq value
+  context 'replace member' do
+    let(:op) { 'replace' }
+    let(:path) { 'members' }
+    let(:value) { [{ 'value' => user3.id.to_s }, { 'value' => user4.id.to_s }] }
+    it {
+      allow(ScimRails.config).to(
+        receive(:mutable_group_attributes_schema).and_return(mutable_attributes_schema)
+      )
+      allow(ScimRails.config).to(
+        receive(:group_member_relation_attribute).and_return(group_member_relation_attribute)
+      )
+      expect(operation.op).to eq 'replace'
+      expect(operation.path_scim).to eq(attribute: 'members', rest_path: [])
+      expect(operation.path_sp).to eq :user_ids
+      expect(operation.value).to eq value
 
-        operation.save(group)
-        expect(group.users).to eq [user3, user4]
-      }
-    end
+      operation.save(group)
+      expect(group.users).to eq [user3, user4]
+    }
+  end
 
-    context 'remove user ids' do
-      let(:op) { 'remove' }
-      let(:path) { 'members' }
-      let(:value) { [{ 'value' => user1.id.to_s }, { 'value' => user2.id.to_s }] }
-      it {
-        allow(ScimRails.config).to(
-          receive(:mutable_group_attributes_schema).and_return(mutable_attributes_schema)
-        )
-        allow(ScimRails.config).to(
-          receive(:group_member_relation_attribute).and_return(group_member_relation_attribute)
-        )
-        expect(operation.op).to eq 'remove'
-        expect(operation.path_scim).to eq(attribute: 'members', rest_path: [])
-        expect(operation.path_sp).to eq :user_ids
-        expect(operation.value).to eq value
+  context 'remove user ids' do
+    let(:op) { 'remove' }
+    let(:path) { 'members' }
+    let(:value) { [{ 'value' => user1.id.to_s }, { 'value' => user2.id.to_s }] }
+    it {
+      allow(ScimRails.config).to(
+        receive(:mutable_group_attributes_schema).and_return(mutable_attributes_schema)
+      )
+      allow(ScimRails.config).to(
+        receive(:group_member_relation_attribute).and_return(group_member_relation_attribute)
+      )
+      expect(operation.op).to eq 'remove'
+      expect(operation.path_scim).to eq(attribute: 'members', rest_path: [])
+      expect(operation.path_sp).to eq :user_ids
+      expect(operation.value).to eq value
 
-        operation.save(group)
-        expect(group.users).to eq []
-      }
-    end
+      operation.save(group)
+      expect(group.users).to eq []
+    }
+  end
 
-    context 'remove user id (with filter)' do
-      let(:op) { 'remove' }
-      let(:path) { "members[value eq \"#{user1.id}\"]" }
-      let(:value) { nil }
-      it {
-        allow(ScimRails.config).to(
-          receive(:mutable_group_attributes_schema).and_return(mutable_attributes_schema)
-        )
-        allow(ScimRails.config).to(
-          receive(:group_member_relation_attribute).and_return(group_member_relation_attribute)
-        )
-        expect(operation.op).to eq 'remove'
-        expect(operation.path_scim).to eq(attribute: 'members',
-                                          filter: { attribute: 'value', operator: 'eq', parameter: user1.id.to_s }, rest_path: [])
-        expect(operation.path_sp).to eq :user_ids
-        expect(operation.value).to eq nil
+  context 'remove user id (with filter)' do
+    let(:op) { 'remove' }
+    let(:path) { "members[value eq \"#{user1.id}\"]" }
+    let(:value) { nil }
+    it {
+      allow(ScimRails.config).to(
+        receive(:mutable_group_attributes_schema).and_return(mutable_attributes_schema)
+      )
+      allow(ScimRails.config).to(
+        receive(:group_member_relation_attribute).and_return(group_member_relation_attribute)
+      )
+      expect(operation.op).to eq 'remove'
+      expect(operation.path_scim).to eq(attribute: 'members',
+                                        filter: { attribute: 'value', operator: 'eq', parameter: user1.id.to_s }, rest_path: [])
+      expect(operation.path_sp).to eq :user_ids
+      expect(operation.value).to eq nil
 
-        operation.save(group)
-        expect(group.users).to eq [user2]
-      }
-    end
+      operation.save(group)
+      expect(group.users).to eq [user2]
+    }
   end
 end

--- a/spec/libraries/scim_patch_operation_group_spec.rb
+++ b/spec/libraries/scim_patch_operation_group_spec.rb
@@ -9,6 +9,12 @@ describe ScimPatchOperationGroup do
   let(:mutable_attributes_schema) { { displayName: :name } }
   let(:group_member_relation_attribute) { :user_ids }
 
+  let(:user1) { create(:user) }
+  let(:user2) { create(:user) }
+  let(:user3) { create(:user) }
+  let(:user4) { create(:user) }
+  let(:group) { create(:group, users: [user1, user2]) }
+
   let(:operation) do
     described_class.new(
       op,
@@ -17,7 +23,7 @@ describe ScimPatchOperationGroup do
     )
   end
   describe '#initialize' do
-    context 'replace single attribute' do
+    context 'replace displayName' do
       it {
         allow(ScimRails.config).to(
           receive(:mutable_group_attributes_schema).and_return(mutable_attributes_schema)
@@ -29,10 +35,13 @@ describe ScimPatchOperationGroup do
         expect(operation.path_scim).to eq(attribute: path, rest_path: [])
         expect(operation.path_sp).to eq :name
         expect(operation.value).to eq value
+
+        operation.save(group)
+        expect(group.name).to eq value
       }
     end
 
-    context 'add single attribute' do
+    context 'add displayName' do
       let(:op) { 'add' }
       it {
         allow(ScimRails.config).to(
@@ -45,10 +54,13 @@ describe ScimPatchOperationGroup do
         expect(operation.path_scim).to eq(attribute: path, rest_path: [])
         expect(operation.path_sp).to eq :name
         expect(operation.value).to eq value
+
+        operation.save(group)
+        expect(group.name).to eq value
       }
     end
 
-    context 'remove single attribute' do
+    context 'remove displayName' do
       let(:op) { 'remove' }
       it {
         allow(ScimRails.config).to(
@@ -61,13 +73,16 @@ describe ScimPatchOperationGroup do
         expect(operation.path_scim).to eq(attribute: path, rest_path: [])
         expect(operation.path_sp).to eq :name
         expect(operation.value).to eq value
+
+        operation.save(group)
+        expect(group.name).to eq nil
       }
     end
 
-    context 'add user ids' do
+    context 'add member' do
       let(:op) { 'add' }
       let(:path) { 'members' }
-      let(:value) { [{ 'value' => '1' }, { 'value' => '2' }] }
+      let(:value) { [{ 'value' => user3.id.to_s }, { 'value' => user4.id.to_s }] }
       it {
         allow(ScimRails.config).to(
           receive(:mutable_group_attributes_schema).and_return(mutable_attributes_schema)
@@ -79,13 +94,37 @@ describe ScimPatchOperationGroup do
         expect(operation.path_scim).to eq(attribute: 'members', rest_path: [])
         expect(operation.path_sp).to eq :user_ids
         expect(operation.value).to eq value
+
+        operation.save(group)
+        expect(group.users).to eq [user1, user2, user3, user4]
+      }
+    end
+
+    context 'replace member' do
+      let(:op) { 'replace' }
+      let(:path) { 'members' }
+      let(:value) { [{ 'value' => user3.id.to_s }, { 'value' => user4.id.to_s }] }
+      it {
+        allow(ScimRails.config).to(
+          receive(:mutable_group_attributes_schema).and_return(mutable_attributes_schema)
+        )
+        allow(ScimRails.config).to(
+          receive(:group_member_relation_attribute).and_return(group_member_relation_attribute)
+        )
+        expect(operation.op).to eq 'replace'
+        expect(operation.path_scim).to eq(attribute: 'members', rest_path: [])
+        expect(operation.path_sp).to eq :user_ids
+        expect(operation.value).to eq value
+
+        operation.save(group)
+        expect(group.users).to eq [user3, user4]
       }
     end
 
     context 'remove user ids' do
       let(:op) { 'remove' }
       let(:path) { 'members' }
-      let(:value) { [{ 'value' => '1' }, { 'value' => '2' }] }
+      let(:value) { [{ 'value' => user1.id.to_s }, { 'value' => user2.id.to_s }] }
       it {
         allow(ScimRails.config).to(
           receive(:mutable_group_attributes_schema).and_return(mutable_attributes_schema)
@@ -96,13 +135,16 @@ describe ScimPatchOperationGroup do
         expect(operation.op).to eq 'remove'
         expect(operation.path_scim).to eq(attribute: 'members', rest_path: [])
         expect(operation.path_sp).to eq :user_ids
-        expect(operation.value).to eq [{ 'value' => '1' }, { 'value' => '2' }]
+        expect(operation.value).to eq value
+
+        operation.save(group)
+        expect(group.users).to eq []
       }
     end
 
     context 'remove user id (with filter)' do
       let(:op) { 'remove' }
-      let(:path) { 'members[value eq "abcdef01"]' }
+      let(:path) { "members[value eq \"#{user1.id}\"]" }
       let(:value) { nil }
       it {
         allow(ScimRails.config).to(
@@ -113,9 +155,12 @@ describe ScimPatchOperationGroup do
         )
         expect(operation.op).to eq 'remove'
         expect(operation.path_scim).to eq(attribute: 'members',
-                                          filter: { attribute: 'value', operator: 'eq', parameter: 'abcdef01' }, rest_path: [])
+                                          filter: { attribute: 'value', operator: 'eq', parameter: user1.id.to_s }, rest_path: [])
         expect(operation.path_sp).to eq :user_ids
         expect(operation.value).to eq nil
+
+        operation.save(group)
+        expect(group.users).to eq [user2]
       }
     end
   end


### PR DESCRIPTION
## Why?

When using feature flag, Azure AD sends removing member request by filter as follows:
```
  "Operations": [
      {
          "op": "remove",
          "path": "members[value eq \"7f4bc1a3-285e-48ae-8202-5accb43efb0e\"]"
      }
```

## What?

Support removing member by path filter