### PR TITLE
Add support for ruby 3.2

### DIFF
--- a/.github/gemfiles/rails-6.1.7.2.Gemfile
+++ b/.github/gemfiles/rails-6.1.7.2.Gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gemspec path: '../..'
+
+gem "rails", "6.1.7.2"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -105,6 +105,8 @@ jobs:
             ruby: 3.2.1
           - rails: 6.0.4.1
             ruby: 3.2.1
+          - rails: 6.1.3.2
+            ruby: 3.2.1
 
     env:
       RAILS_ENV: test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -101,6 +101,8 @@ jobs:
             ruby: 3.0.1
           - rails: 6.0.4.1
             ruby: 3.0.2
+          - rails: 6.0.3.7
+            ruby: 3.2.1
           - rails: 6.0.4.1
             ruby: 3.2.1
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -50,6 +50,8 @@ jobs:
           - 2.6.8
           - 2.7.4
           - 3.0.2
+          # 2023-02-08 release
+          - 3.2.1
         rails:
           ## test against last two releases from supported rails versions
           ## when updating, be sure to add the matching version Gemfile to
@@ -64,6 +66,8 @@ jobs:
           # 2021-08-20 releases
           - 6.0.4.1
           - 6.1.4.1
+          # 2023-01-24 releases
+          - 6.1.7.2
         exclude:
           ## be careful with which versions of ruby does rails support
           ## cf https://www.fastruby.io/blog/ruby/rails/versions/compatibility-table.html
@@ -76,6 +80,8 @@ jobs:
             ruby: 3.0.1
           - rails: 5.2.4.6
             ruby: 3.0.2
+          - rails: 5.2.4.6
+            ruby: 3.2.1
           - rails: 5.2.6
             ruby: 2.7.3
           - rails: 5.2.6
@@ -84,6 +90,8 @@ jobs:
             ruby: 3.0.1
           - rails: 5.2.6
             ruby: 3.0.2
+          - rails: 5.2.6
+            ruby: 3.2.1
           # rails 6.0 requires ruby < 3
           - rails: 6.0.3.7
             ruby: 3.0.1
@@ -93,6 +101,8 @@ jobs:
             ruby: 3.0.1
           - rails: 6.0.4.1
             ruby: 3.0.2
+          - rails: 6.0.4.1
+            ruby: 3.2.1
 
     env:
       RAILS_ENV: test

--- a/scimaenaga.gemspec
+++ b/scimaenaga.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
 
-  s.required_ruby_version = '>= 2.5.9', '< 3.1'
+  s.required_ruby_version = '>= 2.5.9', '< 3.3'
   s.add_dependency 'rails', '>= 5.2.4.6', '< 6.2'
   s.add_runtime_dependency 'jwt', '>= 1.5'
   s.test_files = Dir['spec/**/*']


### PR DESCRIPTION
## Why?

Want to support latest ruby

## What?

* add support for ruby 3.2
* exclude weird rails versions

## Caveats

rails 6.1.3.2 x ruby 3.2.1 alone fails with a database.yml load error.
I don't have the resources to figure out how to test on that version without a database.yml.
