### PR TITLE
return group members

### DIFF
--- a/app/controllers/concerns/scimaenaga/response.rb
+++ b/app/controllers/concerns/scimaenaga/response.rb
@@ -52,14 +52,14 @@ module Scimaenaga
 
       def object_response(object)
         case object
-           when Scimaenaga.config.scim_users_model
-             user_object_response(object)
-           when Scimaenaga.config.scim_groups_model
-             group_object_response(object)
-           else
-             raise Scimaenaga::ExceptionHandler::InvalidQuery,
-                   "Unknown model: #{object}"
-           end
+        when Scimaenaga.config.scim_users_model
+          user_object_response(object)
+        when Scimaenaga.config.scim_groups_model
+          group_object_response(object)
+        else
+          raise Scimaenaga::ExceptionHandler::InvalidQuery,
+                "Unknown model: #{object}"
+        end
       end
 
       def user_object_response(object)
@@ -69,11 +69,11 @@ module Scimaenaga
       def group_object_response(object)
         response = find_value(object, Scimaenaga.config.group_schema.except(:members))
         members_attribute = Scimaenaga.config.group_schema[:members]
-        return if members_attribute.nil?
+        return response if members_attribute.nil?
 
         members_raw = find_value(object, members_attribute)
         response[:members] = members_raw.map do |member|
-          find_value(member, Scimaenaga.config.user_abbreviated_schema )
+          find_value(member, Scimaenaga.config.user_abbreviated_schema)
         end
         response
       end

--- a/app/controllers/concerns/scimaenaga/response.rb
+++ b/app/controllers/concerns/scimaenaga/response.rb
@@ -53,7 +53,7 @@ module Scimaenaga
       def object_response(object)
         case object
            when Scimaenaga.config.scim_users_model
-             user_object_respnse(object)
+             user_object_response(object)
            when Scimaenaga.config.scim_groups_model
              group_object_response(object)
            else

--- a/app/controllers/concerns/scimaenaga/response.rb
+++ b/app/controllers/concerns/scimaenaga/response.rb
@@ -51,16 +51,31 @@ module Scimaenaga
       end
 
       def object_response(object)
-        schema = case object
-                 when Scimaenaga.config.scim_users_model
-                   Scimaenaga.config.user_schema
-                 when Scimaenaga.config.scim_groups_model
-                   Scimaenaga.config.group_schema
-                 else
-                   raise Scimaenaga::ExceptionHandler::InvalidQuery,
-                         "Unknown model: #{object}"
-                 end
-        find_value(object, schema)
+        case object
+           when Scimaenaga.config.scim_users_model
+             user_object_respnse(object)
+           when Scimaenaga.config.scim_groups_model
+             group_object_response(object)
+           else
+             raise Scimaenaga::ExceptionHandler::InvalidQuery,
+                   "Unknown model: #{object}"
+           end
+      end
+
+      def user_object_response(object)
+        find_value(object, Scimaenaga.config.user_schema)
+      end
+
+      def group_object_response(object)
+        response = find_value(object, Scimaenaga.config.group_schema.except(:members))
+        members_attribute = Scimaenaga.config.group_schema[:members]
+        return if members_attribute.nil?
+
+        members_raw = find_value(object, members_attribute)
+        response[:members] = members_raw.map do |member|
+          find_value(member, Scimaenaga.config.user_abbreviated_schema )
+        end
+        response
       end
 
       # `find_value` is a recursive method that takes a "user" and a


### PR DESCRIPTION
## Why?

To be available in "Application Gallery (Azure AD)", we have to support return group members.

## What?

return group members
