### PR TITLE
Add Ruby 3.2.2

### DIFF
--- a/.github/gemfiles/rails-6.1.7.3.Gemfile
+++ b/.github/gemfiles/rails-6.1.7.3.Gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gemspec path: '../..'
+
+gem "rails", "6.1.7.3"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -52,6 +52,8 @@ jobs:
           - 3.0.2
           # 2023-02-08 release
           - 3.2.1
+          # 2023-03-30 release
+          - 3.2.2
         rails:
           ## test against last two releases from supported rails versions
           ## when updating, be sure to add the matching version Gemfile to
@@ -68,6 +70,8 @@ jobs:
           - 6.1.4.1
           # 2023-01-24 releases
           - 6.1.7.2
+          # 2023-03-14 releases
+          - 6.1.7.3
         exclude:
           ## be careful with which versions of ruby does rails support
           ## cf https://www.fastruby.io/blog/ruby/rails/versions/compatibility-table.html
@@ -82,6 +86,8 @@ jobs:
             ruby: 3.0.2
           - rails: 5.2.4.6
             ruby: 3.2.1
+          - rails: 5.2.4.6
+            ruby: 3.2.2
           - rails: 5.2.6
             ruby: 2.7.3
           - rails: 5.2.6
@@ -92,6 +98,8 @@ jobs:
             ruby: 3.0.2
           - rails: 5.2.6
             ruby: 3.2.1
+          - rails: 5.2.6
+            ruby: 3.2.2
           # rails 6.0 requires ruby < 3
           - rails: 6.0.3.7
             ruby: 3.0.1
@@ -107,6 +115,10 @@ jobs:
             ruby: 3.2.1
           - rails: 6.1.3.2
             ruby: 3.2.1
+          - rails: 6.0.3.7
+            ruby: 3.2.2
+          - rails: 6.0.4.1
+            ruby: 3.2.2
 
     env:
       RAILS_ENV: test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,13 +42,8 @@ jobs:
           ##
           ## cf https://endoflife.date/ruby
           # 2021-04-05 releases
-          - 2.5.9
-          - 2.6.7
-          - 2.7.3
           - 3.0.1
           # 2021-07-07 releases
-          - 2.6.8
-          - 2.7.4
           - 3.0.2
           # 2023-02-08 release
           - 3.2.1
@@ -61,8 +56,6 @@ jobs:
           ##
           ## cf https://endoflife.date/rails
           # 2021-05-06 releases
-          - 5.2.4.6
-          - 5.2.6
           - 6.0.3.7
           - 6.1.3.2
           # 2021-08-20 releases
@@ -75,31 +68,6 @@ jobs:
         exclude:
           ## be careful with which versions of ruby does rails support
           ## cf https://www.fastruby.io/blog/ruby/rails/versions/compatibility-table.html
-          # rails 5.2 requires ruby < 2.7
-          - rails: 5.2.4.6
-            ruby: 2.7.3
-          - rails: 5.2.4.6
-            ruby: 2.7.4
-          - rails: 5.2.4.6
-            ruby: 3.0.1
-          - rails: 5.2.4.6
-            ruby: 3.0.2
-          - rails: 5.2.4.6
-            ruby: 3.2.1
-          - rails: 5.2.4.6
-            ruby: 3.2.2
-          - rails: 5.2.6
-            ruby: 2.7.3
-          - rails: 5.2.6
-            ruby: 2.7.4
-          - rails: 5.2.6
-            ruby: 3.0.1
-          - rails: 5.2.6
-            ruby: 3.0.2
-          - rails: 5.2.6
-            ruby: 3.2.1
-          - rails: 5.2.6
-            ruby: 3.2.2
           # rails 6.0 requires ruby < 3
           - rails: 6.0.3.7
             ruby: 3.0.1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -87,6 +87,8 @@ jobs:
             ruby: 3.2.2
           - rails: 6.0.4.1
             ruby: 3.2.2
+          - rails: 6.1.3.2
+            ruby: 3.2.2
 
     env:
       RAILS_ENV: test


### PR DESCRIPTION
## Why?

Want to support latest ruby

## What?

* Add support for ruby 3.2.2
* Add suppory for rails 6.1.7.3
* Remove End of life ruby and rails

## Caveats

N/A
