### PR TITLE
Release: 1.0.0.  ignore CheckEOLRails 

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,6 +23,8 @@ jobs:
         with:
           ruby-version: 3.0.2
       - uses: reviewdog/action-brakeman@v2
+        with:
+          brakeman_flags: --except CheckEOLRails
 
   misspell:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Upcoming Release
 
+
+# v1.0.0 07-06-2023
+
+- [CI: Test against rails 7.0](https://github.com/StudistCorporation/scimaenaga/pull/43)
+
 # v0.9.3 04-27-2023
 
 - [Add Ruby 3.2](https://github.com/StudistCorporation/scimaenaga/pull/41)

--- a/lib/scimaenaga/version.rb
+++ b/lib/scimaenaga/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Scimaenaga
-  VERSION = '0.9.3'
+  VERSION = '1.0.0'
 end


### PR DESCRIPTION
## Why?

There are some EOL rails version, but still we want to keep them so that developer in such environment can use scimaenaga

## What?

ignore CheckEOLRails by brakeman
release 1.0.0