### PR TITLE
Ci against rails7.1

### DIFF
--- a/.github/gemfiles/rails-7.1.Gemfile
+++ b/.github/gemfiles/rails-7.1.Gemfile
@@ -1,0 +1,9 @@
+source 'https://rubygems.org'
+
+gemspec path: '../..'
+
+gem "rails", "~> 7.1"
+
+# Since rails 7.0, rails does not require sprockets-rails.
+# This is added to run the same tests as in previous versions.
+gem 'sprockets-rails'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -72,6 +72,8 @@ jobs:
           - 6.1.7.3
           # 2023-03-13 releases
           - 7.0.4.3
+          # 2023-10-05 releases
+          - 7.1
         exclude:
           ## be careful with which versions of ruby does rails support
           ## cf https://www.fastruby.io/blog/ruby/rails/versions/compatibility-table.html

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,9 @@
 AllCops:
   NewCops: enable
 
+Gemspec/DevelopmentDependencies:
+  Enabled: false
+
 Style/FrozenStringLiteralComment:
   Enabled: true
 

--- a/scimaenaga.gemspec
+++ b/scimaenaga.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
 
   s.required_ruby_version = '>= 2.5.9', '< 3.3'
-  s.add_dependency 'rails', '>= 5.2.4.6', '< 7.1'
+  s.add_dependency 'rails', '>= 5.2.4.6', '< 7.2'
   s.add_runtime_dependency 'jwt', '>= 1.5'
   s.test_files = Dir['spec/**/*']
 

--- a/scimaenaga.gemspec
+++ b/scimaenaga.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'factory_bot_rails'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rake', '~> 13.0'
-  s.add_development_dependency 'rspec-rails', '~> 5.0'
+  s.add_development_dependency 'rspec-rails'
   s.add_development_dependency 'sqlite3', '~> 1.3', '< 1.5'
   s.metadata = {
     'rubygems_mfa_required' => 'true',


### PR DESCRIPTION
## Why?
Rails7.1 was released on 2023/10/05. 
Currently, Scimaenaga can only be used with Rails 7.0 or lower.
This Pull Request is to make Scimaenaga compatible with Rails 7.1.

## What?
* Relax rails dependency version.
* Use the latest version of rspec-rails.