### PR TITLE
Support Ruby 3.3

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -54,6 +54,8 @@ jobs:
           - 3.2.1
           # 2023-03-30 release
           - 3.2.2
+          # 2023-12-25 release
+          - 3.3.0
         rails:
           ## test against last two releases from supported rails versions
           ## when updating, be sure to add the matching version Gemfile to
@@ -98,6 +100,12 @@ jobs:
             ruby: 3.2.2
           - rails: 6.1.3.2
             ruby: 3.2.2
+          - rails: 6.0.3.7
+            ruby: 3.3.0
+          - rails: 6.0.4.1
+            ruby: 3.3.0
+          - rails: 6.1.3.2
+            ruby: 3.3.0
 
     env:
       RAILS_ENV: test

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,9 @@
 AllCops:
   NewCops: enable
 
+Gemspec/RequiredRubyVersion:
+  Enabled: false
+
 Gemspec/DevelopmentDependencies:
   Enabled: false
 

--- a/scimaenaga.gemspec
+++ b/scimaenaga.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
 
-  s.required_ruby_version = '>= 2.5.9', '< 3.3'
+  s.required_ruby_version = '>= 2.5.9', '<= 3.3'
   s.add_dependency 'rails', '>= 5.2.4.6', '< 7.2'
   s.add_runtime_dependency 'jwt', '>= 1.5'
   s.test_files = Dir['spec/**/*']


### PR DESCRIPTION
This PR relaxes the upper Ruby version constraint to support [Ruby 3.3](https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/).
