### PR TITLE
Support 3.3.x (x != 0)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -54,8 +54,8 @@ jobs:
           - 3.2.1
           # 2023-03-30 release
           - 3.2.2
-          # 2023-12-25 release
-          - 3.3.0
+          # 2024-06-12 release
+          - 3.3.3
         rails:
           ## test against last two releases from supported rails versions
           ## when updating, be sure to add the matching version Gemfile to
@@ -101,11 +101,11 @@ jobs:
           - rails: 6.1.3.2
             ruby: 3.2.2
           - rails: 6.0.3.7
-            ruby: 3.3.0
+            ruby: 3.3.3
           - rails: 6.0.4.1
-            ruby: 3.3.0
+            ruby: 3.3.3
           - rails: 6.1.3.2
-            ruby: 3.3.0
+            ruby: 3.3.3
 
     env:
       RAILS_ENV: test

--- a/scimaenaga.gemspec
+++ b/scimaenaga.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
 
-  s.required_ruby_version = '>= 2.5.9', '<= 3.3'
+  s.required_ruby_version = '>= 2.5.9', '< 3.4'
   s.add_dependency 'rails', '>= 5.2.4.6', '< 7.2'
   s.add_runtime_dependency 'jwt', '>= 1.5'
   s.test_files = Dir['spec/**/*']

--- a/scimaenaga.gemspec
+++ b/scimaenaga.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
 
-  s.required_ruby_version = '>= 2.5.9', '< 3.4'
+  s.required_ruby_version = '>= 2.5.9', '<= 3.3.3'
   s.add_dependency 'rails', '>= 5.2.4.6', '< 7.2'
   s.add_runtime_dependency 'jwt', '>= 1.5'
   s.test_files = Dir['spec/**/*']


### PR DESCRIPTION
## Why?

`<= 3.3` means `<= 3.3.0`, so this cannot install with 3.3.1 or later.

```
scimaenaga-1.0.2 requires ruby version >= 2.5.9, <= 3.3, which is incompatible
with the current version, ruby 3.3.3p89
```

## What?

`< 3.4` supports 3.3.x (x != 0) too.

## Caveats

Nothing affects already supported versions.
