### PR TITLE
Support Ruby 3.3.6

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -54,8 +54,8 @@ jobs:
           - 3.2.1
           # 2023-03-30 release
           - 3.2.2
-          # 2024-07-09 release
-          - 3.3.4
+          # 2024-11-11 release
+          - 3.3.6
         rails:
           ## test against last two releases from supported rails versions
           ## when updating, be sure to add the matching version Gemfile to
@@ -101,11 +101,11 @@ jobs:
           - rails: 6.1.3.2
             ruby: 3.2.2
           - rails: 6.0.3.7
-            ruby: 3.3.4
+            ruby: 3.3.6
           - rails: 6.0.4.1
-            ruby: 3.3.4
+            ruby: 3.3.6
           - rails: 6.1.3.2
-            ruby: 3.3.4
+            ruby: 3.3.6
 
     env:
       RAILS_ENV: test

--- a/scimaenaga.gemspec
+++ b/scimaenaga.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
 
-  s.required_ruby_version = '>= 2.5.9', '<= 3.3.4'
+  s.required_ruby_version = '>= 2.5.9', '<= 3.3.6'
   s.add_dependency 'rails', '>= 5.2.4.6', '< 7.2'
   s.add_runtime_dependency 'jwt', '>= 1.5'
   s.test_files = Dir['spec/**/*']


### PR DESCRIPTION
## Why?

Support Ruby 3.3.6.

## What?

Add Ruby 3.3.6 to the test matrix in CI workflow and update scimaenaga.gemspec.