### PR TITLE
Fix CI Failures

### DIFF
--- a/.github/gemfiles/rails-5.2.4.6.Gemfile
+++ b/.github/gemfiles/rails-5.2.4.6.Gemfile
@@ -3,3 +3,4 @@ source 'https://rubygems.org'
 gemspec path: '../..'
 
 gem "rails", "5.2.4.6"
+gem 'concurrent-ruby', '1.3.4'

--- a/.github/gemfiles/rails-5.2.6.Gemfile
+++ b/.github/gemfiles/rails-5.2.6.Gemfile
@@ -3,3 +3,4 @@ source 'https://rubygems.org'
 gemspec path: '../..'
 
 gem "rails", "5.2.6"
+gem 'concurrent-ruby', '1.3.4'

--- a/.github/gemfiles/rails-6.0.3.7.Gemfile
+++ b/.github/gemfiles/rails-6.0.3.7.Gemfile
@@ -3,3 +3,4 @@ source 'https://rubygems.org'
 gemspec path: '../..'
 
 gem "rails", "6.0.3.7"
+gem 'concurrent-ruby', '1.3.4'

--- a/.github/gemfiles/rails-6.0.4.1.Gemfile
+++ b/.github/gemfiles/rails-6.0.4.1.Gemfile
@@ -3,3 +3,4 @@ source 'https://rubygems.org'
 gemspec path: '../..'
 
 gem "rails", "6.0.4.1"
+gem 'concurrent-ruby', '1.3.4'

--- a/.github/gemfiles/rails-6.1.3.2.Gemfile
+++ b/.github/gemfiles/rails-6.1.3.2.Gemfile
@@ -3,3 +3,4 @@ source 'https://rubygems.org'
 gemspec path: '../..'
 
 gem "rails", "6.1.3.2"
+gem 'concurrent-ruby', '1.3.4'

--- a/.github/gemfiles/rails-6.1.4.1.Gemfile
+++ b/.github/gemfiles/rails-6.1.4.1.Gemfile
@@ -3,3 +3,4 @@ source 'https://rubygems.org'
 gemspec path: '../..'
 
 gem "rails", "6.1.4.1"
+gem 'concurrent-ruby', '1.3.4'

--- a/.github/gemfiles/rails-6.1.7.2.Gemfile
+++ b/.github/gemfiles/rails-6.1.7.2.Gemfile
@@ -3,3 +3,4 @@ source 'https://rubygems.org'
 gemspec path: '../..'
 
 gem "rails", "6.1.7.2"
+gem 'concurrent-ruby', '1.3.4'

--- a/.github/gemfiles/rails-6.1.7.3.Gemfile
+++ b/.github/gemfiles/rails-6.1.7.3.Gemfile
@@ -3,3 +3,4 @@ source 'https://rubygems.org'
 gemspec path: '../..'
 
 gem "rails", "6.1.7.3"
+gem 'concurrent-ruby', '1.3.4'

--- a/.github/gemfiles/rails-7.0.4.3.Gemfile
+++ b/.github/gemfiles/rails-7.0.4.3.Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 gemspec path: '../..'
 
 gem "rails", "7.0.4.3"
+gem 'concurrent-ruby', '1.3.4'
 
 # Since rails 7.0, rails does not require sprockets-rails.
 # This is added to run the same tests as in previous versions.

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,7 +9,7 @@ jobs:
   rubocop:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.0.2
@@ -18,7 +18,7 @@ jobs:
   brakeman:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.0.2
@@ -29,7 +29,7 @@ jobs:
   misspell:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.0.2
@@ -112,9 +112,11 @@ jobs:
       BUNDLE_GEMFILE: ${{ github.workspace }}/.github/gemfiles/rails-${{ matrix.rails }}.Gemfile
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: install libsqlite3-dev
+        run: sudo apt-get install libsqlite3-dev
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}


### PR DESCRIPTION
## What and Why

1: Can not build sqlite3
→ ubuntu 24.04.1 does not include libsqlite3-dev.
→ add `sudo apt-get install  libsqlite3-dev`

2: rails db:setup fails
→ [concurrent-ruby 1.3.5 has breaking changes. When use it with Rails < 7.1, rails command will fail.](https://stackoverflow.com/questions/79360526/uninitialized-constant-activesupportloggerthreadsafelevellogger-nameerror)
→ use `concurrent-ruby 1.3.4`
