### PR TITLE
Support Rails 8.0

### DIFF
--- a/.github/gemfiles/rails-7.0.7.2.Gemfile
+++ b/.github/gemfiles/rails-7.0.7.2.Gemfile
@@ -4,6 +4,7 @@ gemspec path: '../..'
 
 gem "rails", "7.0.7.2"
 gem 'concurrent-ruby', '1.3.4'
+gem 'sqlite3', '< 1.8'
 
 # Since rails 7.0, rails does not require sprockets-rails.
 # This is added to run the same tests as in previous versions.

--- a/.github/gemfiles/rails-8.0.2.Gemfile
+++ b/.github/gemfiles/rails-8.0.2.Gemfile
@@ -2,9 +2,7 @@ source 'https://rubygems.org'
 
 gemspec path: '../..'
 
-gem "rails", "7.0.8.7"
-gem 'concurrent-ruby', '1.3.4'
-gem 'sqlite3', '< 1.8'
+gem "rails", "8.0.2"
 
 # Since rails 7.0, rails does not require sprockets-rails.
 # This is added to run the same tests as in previous versions.

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -76,6 +76,8 @@ jobs:
           - 7.2.1.2
           # 2024-12-10 release
           - 7.2.2.1
+          # 2025-03-12 release
+          - 8.0.2
         exclude:
           ## be careful with which versions of ruby does rails support
           ## cf https://www.fastruby.io/blog/ruby/rails/versions/compatibility-table.html
@@ -104,6 +106,11 @@ jobs:
           - rails: 7.2.2.1
             ruby: 3.0.6
           - rails: 7.2.2.1
+            ruby: 3.0.7
+          # rails 8.0 requires ruby >= 3.2
+          - rails: 8.0.2
+            ruby: 3.0.6
+          - rails: 8.0.2
             ruby: 3.0.7
 
     env:

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gemspec
 # Git. Remember to move these dependencies to your gemspec before releasing
 # your gem to rubygems.org.
 
-gem 'rails', '>= 7.0', '< 7.3'
+gem 'rails', '>= 7.0', '< 8.1'
 
 group :development, :test do
   gem 'pry'

--- a/scimaenaga.gemspec
+++ b/scimaenaga.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
 
   s.required_ruby_version = '>= 2.5.9', '<= 3.4.1'
-  s.add_dependency 'rails', '>= 7.0', '< 7.3'
+  s.add_dependency 'rails', '>= 7.0', '< 8.1'
   s.add_runtime_dependency 'jwt', '>= 1.5'
   s.test_files = Dir['spec/**/*']
 
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rake', '~> 13.0'
   s.add_development_dependency 'rspec-rails'
-  s.add_development_dependency 'sqlite3', '< 1.8'
+  s.add_development_dependency 'sqlite3'
   s.metadata = {
     'rubygems_mfa_required' => 'true',
   }


### PR DESCRIPTION
## Why?

Add support for Rails 8.0, which has been recently released. This allows us to leverage new features and incorporate bug fixes from the latest Rails version.

## What?

Added Rails 8.0 to the CI testing matrix. This ensures continuous compatibility checks in the Rails 8.0 environment.

Removed the sqlite3 version constraint from the gemspec, as Rails 8.0 requires `sqlite3 >= 2.1`. Instead, the version required by Rails 7.0 (`sqlite3 ~> 1.4`) is now set in `rails-7.0.x.Gemfile`.

## Caveats

None.

## Testing Notes

- [x] Test that the CI pipeline runs successfully with Rails 8.0
- [x] Test that all existing tests pass with Rails 8.0

## Alternatives Considered

None.

## Further Reading

- https://rubyonrails.org/2024/11/7/rails-8-no-paas-required
- https://rubyonrails.org/2025/3/12/Rails-Version-8-0-2-has-been-released

## Merge Instructions

None.
