### PR TITLE
ruby3.4.3 support

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -58,6 +58,8 @@ jobs:
           - 3.3.7
           # 2024-12-25 release
           - 3.4.1
+          # 2025-4-30 release
+          - 3.4.3
         rails:
           ## test against last two releases from supported rails versions
           ## when updating, be sure to add the matching version Gemfile to

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -98,6 +98,8 @@ jobs:
             ruby: 3.3.7
           - rails: 7.0.7.2
             ruby: 3.4.1
+          - rails: 7.0.7.2
+            ruby: 3.4.3
           - rails: 7.0.8.7
             ruby: 3.4.1
           # rails 7.2 requires ruby >= 3.1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -102,6 +102,8 @@ jobs:
             ruby: 3.4.3
           - rails: 7.0.8.7
             ruby: 3.4.1
+          - rails: 7.0.8.7
+            ruby: 3.4.3
           # rails 7.2 requires ruby >= 3.1
           - rails: 7.2.1.2
             ruby: 3.0.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Upcoming Release
 
+# v1.0.9 05-14-2025
+- [Support Ruby 3.4.3](https://github.com/StudistCorporation/scimaenaga/pull/XX)
+
 # v1.0.8 04-30-2025
 - [Support Rails 8.0](https://github.com/StudistCorporation/scimaenaga/pull/66)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Upcoming Release
 
 # v1.0.9 05-14-2025
-- [Support Ruby 3.4.3](https://github.com/StudistCorporation/scimaenaga/pull/XX)
+- [Support Ruby 3.4.3](https://github.com/StudistCorporation/scimaenaga/pull/68)
 
 # v1.0.8 04-30-2025
 - [Support Rails 8.0](https://github.com/StudistCorporation/scimaenaga/pull/66)

--- a/lib/scimaenaga/version.rb
+++ b/lib/scimaenaga/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Scimaenaga
-  VERSION = '1.0.8'
+  VERSION = '1.0.9'
 end

--- a/scimaenaga.gemspec
+++ b/scimaenaga.gemspec
@@ -16,20 +16,21 @@ Gem::Specification.new do |s|
   s.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
 
   s.required_ruby_version = '>= 2.5.9', '<= 3.4.3'
+  s.add_dependency 'bigdecimal'
   s.add_dependency 'jwt', '>= 1.5'
+  s.add_dependency 'mutex_m'
   s.add_dependency 'rails', '>= 7.0', '< 8.1'
   s.test_files = Dir['spec/**/*']
 
-  s.add_development_dependency 'bundler', '~> 2.0'
+
   s.add_development_dependency 'benchmark'
+  s.add_development_dependency 'bundler', '~> 2.0'
   s.add_development_dependency 'drb'
   s.add_development_dependency 'factory_bot_rails'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rake', '~> 13.0'
   s.add_development_dependency 'rspec-rails'
   s.add_development_dependency 'sqlite3'
-  s.add_dependency 'bigdecimal'
-  s.add_dependency 'mutex_m'
   s.metadata = {
     'rubygems_mfa_required' => 'true',
   }

--- a/scimaenaga.gemspec
+++ b/scimaenaga.gemspec
@@ -21,13 +21,13 @@ Gem::Specification.new do |s|
   s.test_files = Dir['spec/**/*']
 
   s.add_development_dependency 'bundler', '~> 2.0'
+  s.add_development_dependency 'benchmark'
+  s.add_development_dependency 'drb'
   s.add_development_dependency 'factory_bot_rails'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rake', '~> 13.0'
   s.add_development_dependency 'rspec-rails'
   s.add_development_dependency 'sqlite3'
-  s.add_development_dependency 'benchmark'
-  s.add_development_dependency 'drb'
   s.add_dependency 'bigdecimal'
   s.add_dependency 'mutex_m'
   s.metadata = {

--- a/scimaenaga.gemspec
+++ b/scimaenaga.gemspec
@@ -28,6 +28,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'sqlite3'
   s.add_runtime_dependency "bigdecimal"
   s.add_runtime_dependency "mutex_m"
+  s.add_runtime_dependency "benchmark"
+  s.add_runtime_dependency "drb"
   s.metadata = {
     'rubygems_mfa_required' => 'true',
   }

--- a/scimaenaga.gemspec
+++ b/scimaenaga.gemspec
@@ -26,9 +26,9 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake', '~> 13.0'
   s.add_development_dependency 'rspec-rails'
   s.add_development_dependency 'sqlite3'
-  s.add_dependency 'benchmark'
+  s.add_development_dependency 'benchmark'
+  s.add_development_dependency 'drb'
   s.add_dependency 'bigdecimal'
-  s.add_dependency 'drb'
   s.add_dependency 'mutex_m'
   s.metadata = {
     'rubygems_mfa_required' => 'true',

--- a/scimaenaga.gemspec
+++ b/scimaenaga.gemspec
@@ -16,15 +16,11 @@ Gem::Specification.new do |s|
   s.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
 
   s.required_ruby_version = '>= 2.5.9', '<= 3.4.3'
-  s.add_dependency 'bigdecimal'
   s.add_dependency 'jwt', '>= 1.5'
-  s.add_dependency 'mutex_m'
   s.add_dependency 'rails', '>= 7.0', '< 8.1'
   s.test_files = Dir['spec/**/*']
 
-  s.add_development_dependency 'benchmark'
   s.add_development_dependency 'bundler', '~> 2.0'
-  s.add_development_dependency 'drb'
   s.add_development_dependency 'factory_bot_rails'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rake', '~> 13.0'

--- a/scimaenaga.gemspec
+++ b/scimaenaga.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'rails', '>= 7.0', '< 8.1'
   s.test_files = Dir['spec/**/*']
 
-
   s.add_development_dependency 'benchmark'
   s.add_development_dependency 'bundler', '~> 2.0'
   s.add_development_dependency 'drb'

--- a/scimaenaga.gemspec
+++ b/scimaenaga.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
 
-  s.required_ruby_version = '>= 2.5.9', '<= 3.4.1'
+  s.required_ruby_version = '>= 2.5.9', '<= 3.4.3'
   s.add_dependency 'rails', '>= 7.0', '< 8.1'
   s.add_runtime_dependency 'jwt', '>= 1.5'
   s.test_files = Dir['spec/**/*']

--- a/scimaenaga.gemspec
+++ b/scimaenaga.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake', '~> 13.0'
   s.add_development_dependency 'rspec-rails'
   s.add_development_dependency 'sqlite3'
+  s.add_runtime_dependency "bigdecimal"
   s.metadata = {
     'rubygems_mfa_required' => 'true',
   }

--- a/scimaenaga.gemspec
+++ b/scimaenaga.gemspec
@@ -16,8 +16,8 @@ Gem::Specification.new do |s|
   s.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
 
   s.required_ruby_version = '>= 2.5.9', '<= 3.4.3'
+  s.add_dependency 'jwt', '>= 1.5'
   s.add_dependency 'rails', '>= 7.0', '< 8.1'
-  s.add_runtime_dependency 'jwt', '>= 1.5'
   s.test_files = Dir['spec/**/*']
 
   s.add_development_dependency 'bundler', '~> 2.0'
@@ -26,10 +26,10 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake', '~> 13.0'
   s.add_development_dependency 'rspec-rails'
   s.add_development_dependency 'sqlite3'
-  s.add_runtime_dependency "bigdecimal"
-  s.add_runtime_dependency "mutex_m"
-  s.add_runtime_dependency "benchmark"
-  s.add_runtime_dependency "drb"
+  s.add_dependency 'benchmark'
+  s.add_dependency 'bigdecimal'
+  s.add_dependency 'drb'
+  s.add_dependency 'mutex_m'
   s.metadata = {
     'rubygems_mfa_required' => 'true',
   }

--- a/scimaenaga.gemspec
+++ b/scimaenaga.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec-rails'
   s.add_development_dependency 'sqlite3'
   s.add_runtime_dependency "bigdecimal"
+  s.add_runtime_dependency "mutex_m"
   s.metadata = {
     'rubygems_mfa_required' => 'true',
   }


### PR DESCRIPTION
## Why?

Ruby 3.4.3 was released on April 30, 2025.  
This pull request ensures compatibility with Ruby 3.4.3 so that this gem can be used without issues in projects that adopt this version.

It also lays the groundwork for future upgrades by making sure we're compatible with the latest stable Ruby release.

In addition, starting with Ruby 3.4.0, some standard library components such as `benchmark`, `bigdecimal`, `drb`, and `mutex_m` are no longer bundled by default.  
To avoid runtime `LoadError`s and noisy deprecation warnings, this PR explicitly adds those libraries as gem dependencies.

## What?

This pull request includes the following changes to support Ruby 3.4.3:

- Updated `required_ruby_version` in the gemspec to `~> 3.4.3`
- Added Ruby 3.4.3 to the CI test matrix
- Bumped gem version to `1.0.9`
- Updated the `CHANGELOG` to reflect the changes

## Caveats

- Compatibility with Ruby 3.4.3 has only been verified through CI. No large-scale production load testing has been conducted.
- In the rare case that unexpected behavior occurs due to subtle differences in minor Ruby versions, follow-up patches may be necessary.

## Testing Notes

- No special setup is required to test this change
- CI should pass under Ruby 3.4.3
- Please confirm the following:

  - [ ] CI passes with Ruby 3.4.3
  - [ ] `required_ruby_version` in the gemspec includes Ruby 3.4.3
  - [ ] Version is updated to `1.0.9`
  - [ ] `CHANGELOG` is updated accordingly

## Alternatives Considered

We considered skipping Ruby 3.4.3 support for now, but decided to add it early to reduce future friction for developers.

## Further Reading

- [Ruby 3.4.3 Release Notes](https://www.ruby-lang.org/en/news/2025/04/30/ruby-3-4-3-released/)

## Merge Instructions

Please **DO NOT** squash my commits when merging.