### PR TITLE
Rails8.1 support

### DIFF
--- a/.github/gemfiles/rails-8.1.Gemfile
+++ b/.github/gemfiles/rails-8.1.Gemfile
@@ -1,0 +1,9 @@
+source 'https://rubygems.org'
+
+gemspec path: '../..'
+
+gem "rails", "~> 8.1.0"
+
+# Since rails 7.0, rails does not require sprockets-rails.
+# This is added to run the same tests as in previous versions.
+gem 'sprockets-rails'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -61,6 +61,7 @@ jobs:
           - "7.1"
           - "7.2"
           - "8.0"
+          - "8.1"
         exclude:
           ## be careful with which versions of ruby does rails support
           ## cf https://www.fastruby.io/blog/ruby/rails/versions/compatibility-table.html
@@ -78,6 +79,11 @@ jobs:
           - rails: "8.0"
             ruby: "3.0"
           - rails: "8.0"
+            ruby: "3.1"
+          # rails 8.1 requires ruby >= 3.2
+          - rails: "8.1"
+            ruby: "3.0"
+          - rails: "8.1"
             ruby: "3.1"
 
     env:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.0.2
+          ruby-version: "3.4"
       - uses: reviewdog/action-rubocop@v2
 
   brakeman:
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.0.2
+          ruby-version: "3.4"
       - uses: reviewdog/action-brakeman@v2
         with:
           brakeman_flags: --except CheckEOLRails
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.0.2
+          ruby-version: "3.4"
       - uses: reviewdog/action-misspell@v1
         with:
           locale: "US"

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gemspec
 # Git. Remember to move these dependencies to your gemspec before releasing
 # your gem to rubygems.org.
 
-gem 'rails', '>= 7.0', '< 8.1'
+gem 'rails', '>= 7.0', '< 9.0'
 
 group :development, :test do
   gem 'pry'

--- a/lib/scimaenaga/version.rb
+++ b/lib/scimaenaga/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Scimaenaga
-  VERSION = '1.0.10'
+  VERSION = '1.1.0'
 end

--- a/scimaenaga.gemspec
+++ b/scimaenaga.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.5.9'
   s.add_dependency 'jwt', '>= 1.5'
-  s.add_dependency 'rails', '>= 7.0', '< 8.1'
+  s.add_dependency 'rails', '>= 7.0', '< 9.0'
   s.test_files = Dir['spec/**/*']
 
   s.add_development_dependency 'bundler', '~> 2.0'


### PR DESCRIPTION
## Why?
Rails 8.1 has been released, and this gem needs to support it to allow users to upgrade their Rails applications to the latest version.
## What?
This PR adds Rails 8.1 support:
- Add `.github/gemfiles/rails-8.1.Gemfile` for CI testing
- Update CI test matrix to include Rails 8.1 (with Ruby 3.0 and 3.1 excluded since Rails 8.1 requires Ruby >= 3.2)
- Update Rails version constraint from `< 8.1` to `< 9.0` in both `Gemfile` and `scimaenaga.gemspec`
- Bump version from `1.0.10` to `1.1.0`
## Caveats
None.
## Testing Notes

CI will run tests against Rails 8.1 with Ruby 3.2, 3.3, and 3.4.

- [ ] Verify CI passes for Rails 8.1 matrix
- [ ] Verify existing Rails versions still work

## Alternatives Considered

N/A
## Further Reading
- [Rails 8.1 Release Notes](https://edgeguides.rubyonrails.org/8_1_release_notes.html)
- [Ruby/Rails compatibility table](https://www.fastruby.io/blog/ruby/rails/versions/compatibility-table.html)
## Merge Instructions
Please **DO NOT** squash my commits when merging